### PR TITLE
Feat/sdk deploy method

### DIFF
--- a/sdk/src/useInvisibleWallet.ts
+++ b/sdk/src/useInvisibleWallet.ts
@@ -221,8 +221,11 @@ export function useInvisibleWallet(config: WalletConfig): InvisibleWallet {
                 setAddress(walletAddress);
                 localStorage.setItem('invisible_wallet_address', walletAddress);
                 return { walletAddress, alreadyDeployed: true };
-            } catch {
-                // Entry not found → proceed with deployment.
+            } catch (e: unknown) {
+                // Only proceed if the entry was genuinely absent.
+                // Any other error (network failure, RPC down) should bubble up.
+                const msg = e instanceof Error ? e.message : String(e);
+                if (!msg.toLowerCase().includes('not found')) throw e;
             }
 
             // ── Build transaction ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Adds a `deploy()` method to `useInvisibleWallet` so the SDK can submit the
factory deployment transaction, completing the registration flow end-to-end.

## Changes

### `sdk/src/useInvisibleWallet.ts`

**Hook config** — signature changed from `(factoryAddress: string)` to
`(config: WalletConfig)` where `WalletConfig = { factoryAddress, rpcUrl, networkPassphrase }`.
This satisfies the requirement to not hardcode network values.

**`deploy(signerKeypair, publicKeyBytes?)`** — four stages:
1. Resolves the P-256 public key from localStorage or explicit param
2. Pre-computes the wallet address via `computeWalletAddress()` (Issue #2) and checks
   if it's already deployed using `getContractData()` — returns early if so
3. Builds and simulates the factory transaction (`simulation` adds the required ledger footprint)
4. Assembles, signs, submits, and polls `getTransaction()` every 1s until confirmed

**`DeployResult`** — `{ walletAddress: string, alreadyDeployed: boolean }` lets the
caller distinguish a fresh deploy from an already-live wallet.

**`waitForTransaction()`** — standalone polling helper, extracted for clarity.

## Notes
- `signerKeypair` is a traditional Stellar keypair for fee payment only — it does not
  control the wallet
- Timeout is 30 seconds per transaction; polling gives up after 30 attempts (30s)

Closes #4