### PR TITLE
feat: implement `useInvisibleWallet` React hook for WebAuthn-powered …

### DIFF
--- a/sdk/src/useInvisibleWallet.ts
+++ b/sdk/src/useInvisibleWallet.ts
@@ -66,6 +66,8 @@ export type DeployResult = {
 type InvisibleWallet = {
     /** Soroban contract address of the deployed wallet, or null if not yet registered. */
     address: string | null;
+    /** True if the wallet contract has been confirmed to exist on-chain. */
+    isDeployed: boolean;
     isPending: boolean;
     error: string | null;
     /** Create a new passkey credential and compute the deterministic wallet address. */
@@ -91,7 +93,10 @@ type InvisibleWallet = {
      * @param signaturePayload  The 32-byte payload from the Soroban SorobanAuthorizationEntry.
      */
     signAuthEntry: (signaturePayload: Uint8Array) => Promise<WebAuthnSignature | null>;
-    /** Restore an existing wallet session from localStorage. */
+    /**
+     * Restore an existing wallet session from localStorage.
+     * Verifies that the wallet contract actually exists on-chain before setting the address.
+     */
     login: () => Promise<void>;
 };
 
@@ -124,6 +129,7 @@ export function useInvisibleWallet(config: WalletConfig): InvisibleWallet {
     const { factoryAddress, rpcUrl, networkPassphrase } = config;
 
     const [address, setAddress] = useState<string | null>(null);
+    const [isDeployed, setIsDeployed] = useState(false);
     const [isPending, setIsPending] = useState(false);
     const [error, setError] = useState<string | null>(null);
 
@@ -219,6 +225,7 @@ export function useInvisibleWallet(config: WalletConfig): InvisibleWallet {
                 );
                 // Reached here → entry found → already deployed.
                 setAddress(walletAddress);
+                setIsDeployed(true);
                 localStorage.setItem('invisible_wallet_address', walletAddress);
                 return { walletAddress, alreadyDeployed: true };
             } catch (e: unknown) {
@@ -272,6 +279,7 @@ export function useInvisibleWallet(config: WalletConfig): InvisibleWallet {
             }
 
             setAddress(walletAddress);
+            setIsDeployed(true);
             localStorage.setItem('invisible_wallet_address', walletAddress);
             return { walletAddress, alreadyDeployed: false };
 
@@ -287,11 +295,41 @@ export function useInvisibleWallet(config: WalletConfig): InvisibleWallet {
     // ── login ─────────────────────────────────────────────────────────────────
 
     const login = async () => {
-        const stored = localStorage.getItem('invisible_wallet_address');
-        if (stored) {
-            setAddress(stored);
-        } else {
-            setError('No wallet found. Please register first.');
+        setIsPending(true);
+        setError(null);
+        try {
+            const stored = localStorage.getItem('invisible_wallet_address');
+            if (!stored) {
+                setError('No wallet found. Please register first.');
+                return;
+            }
+
+            const server = new SorobanRpc.Server(rpcUrl);
+
+            // Verify the wallet actually exists on-chain before restoring session
+            try {
+                await server.getContractData(
+                    stored,
+                    xdr.ScVal.scvLedgerKeyContractInstance(),
+                    SorobanRpc.Durability.Persistent
+                );
+                // Reached here → entry found → already deployed.
+                setAddress(stored);
+                setIsDeployed(true);
+            } catch (e: unknown) {
+                const msg = e instanceof Error ? e.message : String(e);
+                if (msg.toLowerCase().includes('not found')) {
+                    setError('Wallet not yet deployed. Call deploy() to create it on-chain.');
+                    setAddress(null);
+                    setIsDeployed(false);
+                } else {
+                    throw e; // Real network error
+                }
+            }
+        } catch (err: unknown) {
+            setError(err instanceof Error ? err.message : String(err));
+        } finally {
+            setIsPending(false);
         }
     };
 
@@ -349,5 +387,5 @@ export function useInvisibleWallet(config: WalletConfig): InvisibleWallet {
         }
     };
 
-    return { address, isPending, error, register, deploy, signAuthEntry, login };
+    return { address, isDeployed, isPending, error, register, deploy, signAuthEntry, login };
 }


### PR DESCRIPTION
Closes #10

---

The useInvisibleWallet hook has been updated to verify wallet deployment upon login, rather than merely retrieving the contract address locally.

What was implemented
Added isDeployed state tracking across the lifecycle (login, deploy).
Updated 
login()
 to actively fetch the contract ledger entry leveraging server.getContractData().
When the contract does not exist yet (i.e. 'not found' error), 
login
 skips restoring the address, and sets a contextual "Wallet not yet deployed" error.
isDeployed correctly reflects the wallet's on-chain readiness, and is exposed on the returned 
InvisibleWallet
 interface.
Documented JSDoc for isDeployed and 
login
 methods tracking these new behaviors.