### PR TITLE
feat(wallet): mainnet support — network config, env vars, factory DEPLOY

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,20 @@
-# Stellar network (used by the demo app — Next.js public vars)
+# Repo-level examples
+
+# Wallet frontend
+NEXT_PUBLIC_NETWORK=testnet
+NEXT_PUBLIC_FACTORY_CONTRACT_ID=CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4
+NEXT_PUBLIC_FACTORY_CONTRACT_ID_TESTNET=CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4
+NEXT_PUBLIC_FACTORY_CONTRACT_ID_MAINNET=
+NEXT_PUBLIC_HORIZON_URL=https://horizon-testnet.stellar.org
+NEXT_PUBLIC_SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
+# Required for mainnet wallet builds. Use your provider endpoint from
+# Blockdaemon, Validation Cloud, QuickNode, or your own RPC deployment.
+NEXT_PUBLIC_MAINNET_RPC_URL=
+
+# Demo app (legacy env names)
 NEXT_PUBLIC_RPC_URL=https://soroban-testnet.stellar.org
 NEXT_PUBLIC_NETWORK_PASSPHRASE=Test SDF Network ; September 2015
 NEXT_PUBLIC_FACTORY_ADDRESS=         # output of scripts/deploy_factory.sh
-
 
 # Used by scripts (Node.js — no NEXT_PUBLIC_ prefix)
 RPC_URL=https://soroban-testnet.stellar.org

--- a/contracts/factory/DEPLOY.md
+++ b/contracts/factory/DEPLOY.md
@@ -1,0 +1,139 @@
+# Factory Mainnet Deployment
+
+This guide documents the mainnet deployment flow for the Veil factory contract.
+
+The factory depends on the `invisible_wallet` Wasm hash, so deployment happens in
+three stages:
+
+1. build both contracts
+2. upload the wallet Wasm and capture its hash
+3. deploy the factory contract and initialize it with that wallet Wasm hash
+
+## Prerequisites
+
+- Rust with the `wasm32-unknown-unknown` target
+- `stellar` CLI installed
+- a funded mainnet deployer identity
+- a mainnet Soroban RPC provider URL
+
+```bash
+rustup target add wasm32-unknown-unknown
+stellar version
+```
+
+Set the shared deployment inputs:
+
+```bash
+export MAINNET_RPC_URL="https://your-mainnet-rpc-provider.example.com"
+export NETWORK_PASSPHRASE="Public Global Stellar Network ; September 2015"
+export DEPLOYER_ALIAS="veil-mainnet"
+```
+
+If you have not created the deployer identity yet:
+
+```bash
+stellar keys generate --global "$DEPLOYER_ALIAS"
+stellar keys address "$DEPLOYER_ALIAS"
+```
+
+Fund that address with enough XLM to cover Wasm upload, contract deployment, and
+the follow-up initialization transaction.
+
+## 1. Build the Wasm artifacts
+
+From the repo root:
+
+```bash
+cd contracts/invisible_wallet
+cargo build --target wasm32-unknown-unknown --release
+
+cd ../factory
+cargo build --target wasm32-unknown-unknown --release
+```
+
+The generated artifacts are:
+
+- `contracts/invisible_wallet/target/wasm32-unknown-unknown/release/invisible_wallet.wasm`
+- `contracts/factory/target/wasm32-unknown-unknown/release/factory.wasm`
+
+## 2. Upload the wallet Wasm
+
+Upload the wallet code first and keep the returned hash:
+
+```bash
+cd /path/to/veil
+
+WALLET_WASM_HASH=$(stellar contract upload \
+  --rpc-url "$MAINNET_RPC_URL" \
+  --network-passphrase "$NETWORK_PASSPHRASE" \
+  --source-account "$DEPLOYER_ALIAS" \
+  --wasm contracts/invisible_wallet/target/wasm32-unknown-unknown/release/invisible_wallet.wasm)
+
+echo "$WALLET_WASM_HASH"
+```
+
+That hash is what the factory stores during `init`.
+
+## 3. Deploy the factory contract
+
+Deploy the compiled factory Wasm:
+
+```bash
+FACTORY_CONTRACT_ID=$(stellar contract deploy \
+  --rpc-url "$MAINNET_RPC_URL" \
+  --network-passphrase "$NETWORK_PASSPHRASE" \
+  --source-account "$DEPLOYER_ALIAS" \
+  --wasm contracts/factory/target/wasm32-unknown-unknown/release/factory.wasm)
+
+echo "$FACTORY_CONTRACT_ID"
+```
+
+## 4. Initialize the factory with the wallet Wasm hash
+
+Call the factory's `init` entrypoint with the uploaded wallet Wasm hash:
+
+```bash
+stellar contract invoke \
+  --rpc-url "$MAINNET_RPC_URL" \
+  --network-passphrase "$NETWORK_PASSPHRASE" \
+  --source-account "$DEPLOYER_ALIAS" \
+  --id "$FACTORY_CONTRACT_ID" \
+  -- init \
+  --wasm-hash "$WALLET_WASM_HASH"
+```
+
+If your local CLI version exposes a slightly different generated flag name for
+the `init` argument, run:
+
+```bash
+stellar contract invoke \
+  --rpc-url "$MAINNET_RPC_URL" \
+  --network-passphrase "$NETWORK_PASSPHRASE" \
+  --source-account "$DEPLOYER_ALIAS" \
+  --id "$FACTORY_CONTRACT_ID" \
+  -- --help
+```
+
+## 5. Record the deployment outputs
+
+Capture both values for the release notes:
+
+- `WALLET_WASM_HASH`
+- `FACTORY_CONTRACT_ID`
+
+The frontend mainnet deployment should then set:
+
+```bash
+NEXT_PUBLIC_NETWORK=mainnet
+NEXT_PUBLIC_MAINNET_RPC_URL=$MAINNET_RPC_URL
+NEXT_PUBLIC_FACTORY_CONTRACT_ID_MAINNET=$FACTORY_CONTRACT_ID
+```
+
+## Notes
+
+- The actual mainnet deployment should be performed by the maintainer because it
+  spends real XLM.
+- Reuse the same RPC provider URL in the frontend so wallet reads and writes hit
+  the same network.
+- After deployment, verify the factory on-chain before pointing production
+  traffic at it.

--- a/frontend/wallet/.env.example
+++ b/frontend/wallet/.env.example
@@ -1,11 +1,26 @@
 # Veil Wallet — Environment Variables
 # Copy to .env.local and fill in your values
 
-# Factory contract ID on Stellar Testnet
+# Active wallet network (testnet | mainnet)
+NEXT_PUBLIC_NETWORK=testnet
+
+# Testnet factory contract ID.
+# Kept for backwards compatibility with older local setups.
 NEXT_PUBLIC_FACTORY_CONTRACT_ID=CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4
 
-# Network (testnet | mainnet)
-NEXT_PUBLIC_NETWORK=testnet
+# Preferred explicit per-network factory contract IDs.
+NEXT_PUBLIC_FACTORY_CONTRACT_ID_TESTNET=CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4
+NEXT_PUBLIC_FACTORY_CONTRACT_ID_MAINNET=
+
+# Optional testnet endpoint overrides.
+NEXT_PUBLIC_HORIZON_URL=https://horizon-testnet.stellar.org
+NEXT_PUBLIC_SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
+
+# Mainnet Soroban RPC endpoint.
+# Required when NEXT_PUBLIC_NETWORK=mainnet because Stellar does not provide a
+# public Soroban RPC for mainnet. Use your provider endpoint from Blockdaemon,
+# Validation Cloud, QuickNode, or a self-hosted RPC service.
+NEXT_PUBLIC_MAINNET_RPC_URL=
 
 # Agent WebSocket server
 NEXT_PUBLIC_AGENT_WS_URL=ws://localhost:3001

--- a/frontend/wallet/README.md
+++ b/frontend/wallet/README.md
@@ -174,10 +174,12 @@ Set these in Vercel (or `.env.local` for local dev):
 | Variable | Description |
 |---|---|
 | `NEXT_PUBLIC_NETWORK` | `testnet` or `mainnet` |
-| `NEXT_PUBLIC_FACTORY_CONTRACT_ID` | Soroban factory contract address |
-| `NEXT_PUBLIC_HORIZON_URL` | Horizon API URL |
-| `NEXT_PUBLIC_SOROBAN_RPC_URL` | Soroban RPC URL |
-| `NEXT_PUBLIC_NETWORK_PASSPHRASE` | Stellar network passphrase |
+| `NEXT_PUBLIC_FACTORY_CONTRACT_ID_TESTNET` | Testnet factory contract address |
+| `NEXT_PUBLIC_FACTORY_CONTRACT_ID_MAINNET` | Mainnet factory contract address |
+| `NEXT_PUBLIC_FACTORY_CONTRACT_ID` | Legacy fallback for testnet-only setups |
+| `NEXT_PUBLIC_HORIZON_URL` | Optional testnet Horizon override |
+| `NEXT_PUBLIC_SOROBAN_RPC_URL` | Optional testnet Soroban RPC override |
+| `NEXT_PUBLIC_MAINNET_RPC_URL` | Mainnet Soroban RPC provider URL |
 | `NEXT_PUBLIC_WRAITH_URL` | Wraith indexer URL (transfer history) |
 | `NEXT_PUBLIC_AGENT_WS_URL` | Veil Agent WebSocket URL |
 

--- a/frontend/wallet/app/agent/page.tsx
+++ b/frontend/wallet/app/agent/page.tsx
@@ -4,7 +4,10 @@ import { useState, useEffect, useRef, useCallback } from 'react'
 import { useRouter } from 'next/navigation'
 import { Keypair } from '@stellar/stellar-sdk'
 import { useInactivityLock } from '@/hooks/useInactivityLock'
+import { getNetwork } from '@/lib/network'
 import { requirePasskey } from '@/lib/passkeyAuth'
+
+const network = getNetwork()
 
 interface Message {
   role: 'user' | 'agent'
@@ -304,14 +307,10 @@ export default function AgentPage() {
       }
 
       const { Keypair, TransactionBuilder, Horizon } = await import('@stellar/stellar-sdk')
-      const horizonUrl = process.env.NEXT_PUBLIC_HORIZON_URL ?? 'https://horizon-testnet.stellar.org'
-      const networkPassphrase =
-        process.env.NEXT_PUBLIC_NETWORK_PASSPHRASE ?? 'Test SDF Network ; September 2015'
-
       const feePayer = Keypair.fromSecret(signerSecret)
-      const horizonServer = new Horizon.Server(horizonUrl)
+      const horizonServer = new Horizon.Server(network.horizonUrl)
 
-      const tx = TransactionBuilder.fromXDR(xdrToSubmit, networkPassphrase)
+      const tx = TransactionBuilder.fromXDR(xdrToSubmit, network.networkPassphrase)
       tx.sign(feePayer)
 
       const result = await horizonServer.submitTransaction(tx)

--- a/frontend/wallet/app/dashboard/page.tsx
+++ b/frontend/wallet/app/dashboard/page.tsx
@@ -12,9 +12,12 @@ import { TxDetailSheet, type TxRecord } from '@/components/TxDetailSheet'
 import { useInactivityLock } from '@/hooks/useInactivityLock'
 import { deriveStoredFeePayer } from '@/lib/deriveFeePayer'
 import { fetchPrices } from '@/lib/fetchPrice'
+import { buildFriendbotUrl, getNativeAssetContractId, getNetwork } from '@/lib/network'
 import { sweepContractBalance } from '@/lib/sweepContractBalance'
 import { derToRawSignature, hexToUint8Array } from '@veil/utils'
 import type { WebAuthnSignature } from '@veil/sdk'
+
+const network = getNetwork()
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -46,8 +49,6 @@ export default function DashboardPage() {
   const [sweepError, setSweepError]         = useState<string | null>(null)
   const [sweepDismissed, setSweepDismissed] = useState(false)
 
-  const isTestnet = process.env.NEXT_PUBLIC_NETWORK === 'testnet'
-
   useEffect(() => {
     const stored = sessionStorage.getItem('invisible_wallet_address')
     if (!stored) { router.replace('/lock'); return }
@@ -65,27 +66,20 @@ export default function DashboardPage() {
     if (!walletAddress) return   // keep loading=true until address is ready
     setLoading(true)
 
-    const horizonUrl = isTestnet
-      ? 'https://horizon-testnet.stellar.org'
-      : 'https://horizon.stellar.org'
-    const rpcUrl = isTestnet
-      ? 'https://soroban-testnet.stellar.org'
-      : 'https://soroban.stellar.org'
-
-    const horizonServer = new Server(horizonUrl)
-    const rpcServer     = new SorobanRpc.Server(rpcUrl)
+    const horizonServer = new Server(network.horizonUrl)
+    const rpcServer     = new SorobanRpc.Server(network.rpcUrl)
 
     // ── 1. Wallet contract (C...) XLM balance via native SAC ────────────────
     // This is the canonical on-chain balance — survives cache clears and
     // cross-device recovery because it reads directly from the ledger.
     let contractXlm = 0
     try {
-      const sacAddress  = Asset.native().contractId(Networks.TESTNET)
+      const sacAddress  = getNativeAssetContractId()
       const sacContract = new Contract(sacAddress)
       const dummyKp     = Keypair.random()
       const dummyAcct   = new Account(dummyKp.publicKey(), '0')
       const balanceTx   = new TransactionBuilder(dummyAcct, {
-        fee: BASE_FEE, networkPassphrase: Networks.TESTNET,
+        fee: BASE_FEE, networkPassphrase: network.networkPassphrase,
       })
         .addOperation(sacContract.call('balance', nativeToScVal(walletAddress, { type: 'address' })))
         .setTimeout(30)
@@ -265,7 +259,7 @@ export default function DashboardPage() {
     ])
     setTransactions(txRecords)
     setLoading(false)
-  }, [walletAddress, isTestnet])
+  }, [walletAddress])
 
   useEffect(() => {
     fetchData()
@@ -318,7 +312,16 @@ export default function DashboardPage() {
       if (currentSecret && !localStorage.getItem('veil_signer_secret')) {
         localStorage.setItem('veil_signer_secret', currentSecret)
       }
-      const res = await fetch(`https://friendbot.stellar.org/?addr=${signerPublicKey}`)
+      const friendbotUrl = buildFriendbotUrl(signerPublicKey)
+      if (!friendbotUrl) {
+        await fetchData()
+        setFundingError(
+          `Fee-payer restored. Fund ${signerPublicKey} with XLM from an external wallet to send or swap on mainnet.`
+        )
+        return
+      }
+
+      const res = await fetch(friendbotUrl)
       if (!res.ok) {
         // 400 means the account is already funded — just refresh balances
         if (res.status === 400) {
@@ -347,9 +350,6 @@ export default function DashboardPage() {
         || localStorage.getItem('veil_signer_secret')
       if (!signerSecret) throw new Error('Signing key not found. Return to dashboard and tap "Set up fee-payer".')
       const feePayerKp = Keypair.fromSecret(signerSecret)
-
-      const rpcUrl          = isTestnet ? 'https://soroban-testnet.stellar.org' : 'https://soroban.stellar.org'
-      const networkPassphrase = isTestnet ? Networks.TESTNET : Networks.PUBLIC
 
       const localSignAuthEntry = async (payload: Uint8Array): Promise<WebAuthnSignature | null> => {
         const keyId        = localStorage.getItem('invisible_wallet_key_id')
@@ -382,7 +382,13 @@ export default function DashboardPage() {
         }
       }
 
-      await sweepContractBalance(walletAddress!, feePayerKp, localSignAuthEntry, rpcUrl, networkPassphrase)
+      await sweepContractBalance(
+        walletAddress!,
+        feePayerKp,
+        localSignAuthEntry,
+        network.rpcUrl,
+        network.networkPassphrase,
+      )
       setSweepDismissed(false)
       await fetchData()
     } catch (err: unknown) {
@@ -544,7 +550,7 @@ export default function DashboardPage() {
           )}
 
           {/* Faucet button for unfunded or zero-balance testnet wallets */}
-          {isTestnet && !loading && (xlmBalance === null || xlmBalance === '0') && (
+          {network.friendbotUrl && !loading && (xlmBalance === null || xlmBalance === '0') && (
             <div style={{ marginTop: '1.25rem' }}>
               <button
                 className="btn-ghost"

--- a/frontend/wallet/app/lock/page.tsx
+++ b/frontend/wallet/app/lock/page.tsx
@@ -5,21 +5,13 @@ import { useRouter } from 'next/navigation'
 import { LockKeyhole, Fingerprint, AlertCircle } from 'lucide-react'
 import { useInvisibleWallet } from '@veil/sdk'
 import { deriveStoredFeePayer } from '@/lib/deriveFeePayer'
-
-// ── Config ────────────────────────────────────────────────────────────────────
-const FACTORY_ADDRESS    = process.env.NEXT_PUBLIC_FACTORY_CONTRACT_ID ?? ''
-const RPC_URL            = 'https://soroban-testnet.stellar.org'
-const NETWORK_PASSPHRASE = 'Test SDF Network ; September 2015'
+import { walletConfig } from '@/lib/network'
 
 // ── Lock screen ───────────────────────────────────────────────────────────────
 export default function LockPage() {
   const router = useRouter()
 
-  const wallet = useInvisibleWallet({
-    factoryAddress:    FACTORY_ADDRESS,
-    rpcUrl:            RPC_URL,
-    networkPassphrase: NETWORK_PASSPHRASE,
-  })
+  const wallet = useInvisibleWallet(walletConfig)
 
   const [error, setError]           = useState<string | null>(null)
   const [isUnlocking, setIsUnlocking] = useState(false)

--- a/frontend/wallet/app/page.tsx
+++ b/frontend/wallet/app/page.tsx
@@ -2,18 +2,16 @@
 
 import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
-import { Keypair } from '@stellar/stellar-sdk'
+import { Horizon, Keypair } from '@stellar/stellar-sdk'
 import { VeilLogo } from '@/components/VeilLogo'
 import { OnboardingTutorial } from '@/components/OnboardingTutorial'
 import { useInvisibleWallet } from '@veil/sdk'
 import { deriveFeePayerKeypair } from '@/lib/deriveFeePayer'
+import { buildFriendbotUrl, getNetwork, walletConfig } from '@/lib/network'
 import { trackWalletCreated } from '@/lib/supabase'
 
-const CONFIG = {
-  rpcUrl: 'https://soroban-testnet.stellar.org',
-  networkPassphrase: 'Test SDF Network ; September 2015',
-  factoryAddress: process.env.NEXT_PUBLIC_FACTORY_CONTRACT_ID ?? '',
-}
+const network = getNetwork()
+const HorizonServer = Horizon.Server
 
 type Step = 'landing' | 'registering' | 'deploying' | 'done'
 
@@ -42,29 +40,50 @@ export default function OnboardingPage() {
     setShowTutorial(false)
   }
 
-  const wallet = useInvisibleWallet(CONFIG)
+  const wallet = useInvisibleWallet(walletConfig)
 
   async function handleCreate() {
     setError(null)
-    setStep('registering')
     let success = false
+    let signerKeypair: Keypair | null = null
     try {
-      const result = await wallet.register()
-      if (!result) throw new Error('Registration returned no result')
+      const hasStoredPasskey =
+        !!localStorage.getItem('invisible_wallet_key_id')
+        && !!localStorage.getItem('invisible_wallet_public_key')
+
+      if (!hasStoredPasskey) {
+        setStep('registering')
+        const result = await wallet.register()
+        if (!result) throw new Error('Registration returned no result')
+      }
 
       setStep('deploying')
       // Derive fee-payer deterministically from the passkey credential ID.
       // On cache clear the same passkey → same credential ID → same keypair.
       const credentialId = localStorage.getItem('invisible_wallet_key_id')
       if (!credentialId) throw new Error('Passkey credential not found after registration')
-      const signerKeypair = await deriveFeePayerKeypair(credentialId)
-      const signerSecret  = signerKeypair.secret()
+      signerKeypair = await deriveFeePayerKeypair(credentialId)
+      const signerSecret = signerKeypair.secret()
 
-      // Fund the fee-payer keypair via Friendbot before deploying on testnet
-      const friendbotRes = await fetch(
-        `https://friendbot.stellar.org/?addr=${signerKeypair.publicKey()}`
-      )
-      if (!friendbotRes.ok) throw new Error('Friendbot funding failed — try again')
+      // Persist the signer before deploy so a failed mainnet attempt can be retried
+      // after the account is funded externally.
+      localStorage.setItem('veil_signer_public_key', signerKeypair.publicKey())
+      localStorage.setItem('veil_signer_secret', signerSecret)
+
+      const friendbotUrl = buildFriendbotUrl(signerKeypair.publicKey())
+      if (friendbotUrl) {
+        const friendbotRes = await fetch(friendbotUrl)
+        if (!friendbotRes.ok) throw new Error('Friendbot funding failed — try again')
+      } else {
+        const horizonServer = new HorizonServer(network.horizonUrl)
+        try {
+          await horizonServer.loadAccount(signerKeypair.publicKey())
+        } catch {
+          throw new Error(
+            `Mainnet deployment requires a funded signer account. Fund ${signerKeypair.publicKey()} with XLM for fees, then tap Create wallet again.`
+          )
+        }
+      }
 
       // Pass secret string so the SDK uses its own Keypair instance internally,
       // avoiding XDR type mismatches between two stellar-sdk copies.
@@ -73,10 +92,6 @@ export default function OnboardingPage() {
       // Persist minimal session to sessionStorage for the dashboard
       sessionStorage.setItem('invisible_wallet_address', deployed.walletAddress)
       sessionStorage.setItem('veil_signer_secret', signerSecret)
-      // Store fee-payer keys in localStorage so they survive lock/unlock cycles.
-      localStorage.setItem('veil_signer_public_key', signerKeypair.publicKey())
-      localStorage.setItem('veil_signer_secret', signerSecret)
-
       setAddress(deployed.walletAddress)
       setStep('done')
       success = true
@@ -84,7 +99,15 @@ export default function OnboardingPage() {
       // Track wallet creation (fire-and-forget — never blocks the flow)
       trackWalletCreated(deployed.walletAddress, signerKeypair.publicKey())
     } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : String(err)
+      let msg = err instanceof Error ? err.message : String(err)
+      if (
+        !network.friendbotUrl
+        && signerKeypair
+        && !msg.includes(signerKeypair.publicKey())
+        && /account|source|balance|insufficient/i.test(msg)
+      ) {
+        msg = `Mainnet deployment requires a funded signer account. Fund ${signerKeypair.publicKey()} with XLM for fees, then tap Create wallet again.`
+      }
       setError(msg)
       setStep('landing')
     }
@@ -149,7 +172,7 @@ export default function OnboardingPage() {
             <p style={{ fontSize: '0.8125rem', color: 'rgba(246,247,248,0.4)', marginTop: '0.5rem' }}>
               {step === 'registering'
                 ? 'Approve the passkey prompt on your device'
-                : 'Broadcasting to Stellar Testnet'}
+                : `Broadcasting to ${network.displayName}`}
             </p>
           </div>
         )}

--- a/frontend/wallet/app/recover/page.tsx
+++ b/frontend/wallet/app/recover/page.tsx
@@ -5,14 +5,13 @@ import { useRouter } from 'next/navigation'
 import { VeilLogo } from '@/components/VeilLogo'
 import { derToRawSignature, bufferToHex } from '@veil/utils'
 import { deriveFeePayerKeypair } from '@/lib/deriveFeePayer'
+import { getNetwork } from '@/lib/network'
 import {
   rpc as SorobanRpc, Contract, TransactionBuilder, BASE_FEE,
-  Account, Keypair, Networks, scValToNative,
+  Account, Keypair, scValToNative,
 } from '@stellar/stellar-sdk'
 
-const RPC_URL            = 'https://soroban-testnet.stellar.org'
-const NETWORK_PASSPHRASE = Networks.TESTNET
-const FACTORY_ADDRESS    = process.env.NEXT_PUBLIC_FACTORY_CONTRACT_ID ?? ''
+const network = getNetwork()
 
 type Step = 'idle' | 'authenticating' | 'done' | 'error'
 
@@ -33,7 +32,7 @@ export default function RecoverPage() {
     setStep('authenticating')
 
     try {
-      const server = new SorobanRpc.Server(RPC_URL)
+      const server = new SorobanRpc.Server(network.rpcUrl)
 
       // ── 1. Fetch on-chain signers ────────────────────────────────────────
       const dummyKp      = Keypair.random()
@@ -42,7 +41,7 @@ export default function RecoverPage() {
 
       const tx = new TransactionBuilder(sourceAcct, {
         fee: BASE_FEE,
-        networkPassphrase: NETWORK_PASSPHRASE,
+        networkPassphrase: network.networkPassphrase,
       })
         .addOperation(walletContract.call('get_signers'))
         .setTimeout(30)

--- a/frontend/wallet/app/send/page.tsx
+++ b/frontend/wallet/app/send/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useRef } from 'react'
 import { useRouter } from 'next/navigation'
 import {
-  Keypair, Networks, TransactionBuilder, BASE_FEE, Asset, Operation,
+  Keypair, TransactionBuilder, BASE_FEE, Asset, Operation,
   Contract, rpc as SorobanRpc, nativeToScVal, Horizon,
 } from '@stellar/stellar-sdk'
 const Server = Horizon.Server
@@ -11,7 +11,10 @@ import { VeilLogo } from '@/components/VeilLogo'
 import { ContactPicker } from '@/components/ContactPicker'
 import { QrScanner } from '@/components/QrScanner'
 import { useInactivityLock } from '@/hooks/useInactivityLock'
+import { getNativeAssetContractId, getNetwork } from '@/lib/network'
 import { beginTx, endTx } from '@/lib/txState'
+
+const network = getNetwork()
 
 type Step = 'form' | 'confirm' | 'signing' | 'done' | 'error'
 
@@ -53,25 +56,25 @@ export default function SendPage() {
       ? Keypair.fromSecret(sessionStorage.getItem('veil_signer_secret')!).publicKey()
       : localStorage.getItem('veil_signer_public_key') || null
     if (!signerPublicKey || !signerPublicKey.startsWith('G')) {
-      const xlm: WalletAsset = { code: 'XLM', issuer: null, contractId: Asset.native().contractId(Networks.TESTNET) }
+      const xlm: WalletAsset = { code: 'XLM', issuer: null, contractId: getNativeAssetContractId() }
       setAssets([xlm])
       setSelectedAsset(xlm)
       return
     }
-    const server = new Server('https://horizon-testnet.stellar.org')
+    const server = new Server(network.horizonUrl)
     server.loadAccount(signerPublicKey).then(account => {
       const list: WalletAsset[] = account.balances.map(b => {
         if (b.asset_type === 'native') {
-          return { code: 'XLM', issuer: null, contractId: Asset.native().contractId(Networks.TESTNET) }
+          return { code: 'XLM', issuer: null, contractId: getNativeAssetContractId() }
         }
         const issued = b as { asset_code: string; asset_issuer: string }
         const asset  = new Asset(issued.asset_code, issued.asset_issuer)
-        return { code: issued.asset_code, issuer: issued.asset_issuer, contractId: asset.contractId(Networks.TESTNET) }
+        return { code: issued.asset_code, issuer: issued.asset_issuer, contractId: asset.contractId(network.networkPassphrase) }
       })
       setAssets(list)
       if (list.length > 0) setSelectedAsset(list[0])
     }).catch(() => {
-      const xlm: WalletAsset = { code: 'XLM', issuer: null, contractId: Asset.native().contractId(Networks.TESTNET) }
+      const xlm: WalletAsset = { code: 'XLM', issuer: null, contractId: getNativeAssetContractId() }
       setAssets([xlm])
       setSelectedAsset(xlm)
     })
@@ -168,13 +171,13 @@ export default function SendPage() {
       })
       if (!assertion) throw new Error('Passkey verification was cancelled.')
 
-      const horizonServer = new Server('https://horizon-testnet.stellar.org')
+      const horizonServer = new Server(network.horizonUrl)
 
       if (recipient.startsWith('G') && recipient.length === 56) {
         const account = await horizonServer.loadAccount(feePayerKp.publicKey())
         const tx = new TransactionBuilder(account, {
           fee: BASE_FEE,
-          networkPassphrase: Networks.TESTNET,
+          networkPassphrase: network.networkPassphrase,
         })
           .addOperation(Operation.payment({
             destination: recipient,
@@ -187,14 +190,14 @@ export default function SendPage() {
         const result = await horizonServer.submitTransaction(tx)
         setTxHash(result.hash)
       } else {
-        const rpcServer     = new SorobanRpc.Server('https://soroban-testnet.stellar.org')
+        const rpcServer     = new SorobanRpc.Server(network.rpcUrl)
         const feePayerAcct  = await rpcServer.getAccount(feePayerKp.publicKey())
-        const sacContract   = new Contract(Asset.native().contractId(Networks.TESTNET))
+        const sacContract   = new Contract(getNativeAssetContractId())
         const amountStroops = BigInt(Math.round(parseFloat(amount) * 10_000_000))
 
         const tx = new TransactionBuilder(feePayerAcct, {
           fee: BASE_FEE,
-          networkPassphrase: Networks.TESTNET,
+          networkPassphrase: network.networkPassphrase,
         })
           .addOperation(sacContract.call(
             'transfer',

--- a/frontend/wallet/app/settings/page.tsx
+++ b/frontend/wallet/app/settings/page.tsx
@@ -6,12 +6,7 @@ import { Keypair } from '@stellar/stellar-sdk'
 import { VeilLogo } from '@/components/VeilLogo'
 import { ThemeToggle } from '@/components/ThemeToggle'
 import { useInvisibleWallet, type SignerInfo } from '@veil/sdk'
-
-const CONFIG = {
-  rpcUrl: 'https://soroban-testnet.stellar.org',
-  networkPassphrase: 'Test SDF Network ; September 2015',
-  factoryAddress: process.env.NEXT_PUBLIC_FACTORY_CONTRACT_ID ?? '',
-}
+import { walletConfig } from '@/lib/network'
 
 type Section = 'overview' | 'add-signer' | 'guardian'
 
@@ -28,7 +23,7 @@ export default function SettingsPage() {
   // Guardian form
   const [guardianAddress, setGuardianAddress] = useState('')
 
-  const wallet = useInvisibleWallet(CONFIG)
+  const wallet = useInvisibleWallet(walletConfig)
 
   useEffect(() => {
     const addr = sessionStorage.getItem('invisible_wallet_address')

--- a/frontend/wallet/app/swap/page.tsx
+++ b/frontend/wallet/app/swap/page.tsx
@@ -2,12 +2,15 @@
 
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { useRouter } from 'next/navigation'
-import { Keypair, Networks, TransactionBuilder, BASE_FEE, Operation, Asset, Memo, Horizon } from '@stellar/stellar-sdk'
+import { Keypair, TransactionBuilder, BASE_FEE, Operation, Asset, Memo, Horizon } from '@stellar/stellar-sdk'
 const Server = Horizon.Server
 import { VeilLogo } from '@/components/VeilLogo'
 import { useInactivityLock } from '@/hooks/useInactivityLock'
+import { getNetwork } from '@/lib/network'
 import { beginTx, endTx } from '@/lib/txState'
 import { requirePasskey } from '@/lib/passkeyAuth'
+
+const network = getNetwork()
 
 // ── Constants ──────────────────────────────────────────────────────────────────
 const DEBOUNCE_MS = 500
@@ -45,8 +48,7 @@ export default function SwapPage() {
   const [errorMsg, setErrorMsg] = useState<string | null>(null)
   const [txHash, setTxHash] = useState<string | null>(null)
 
-  const horizonUrl = 'https://horizon-testnet.stellar.org'
-  const server = new Server(horizonUrl)
+  const server = new Server(network.horizonUrl)
 
   // ── Load session ──
   useEffect(() => {
@@ -68,7 +70,7 @@ export default function SwapPage() {
         return
       }
 
-      const res = await fetch(`${horizonUrl}/accounts/${accountAddr}`)
+      const res = await fetch(`${network.horizonUrl}/accounts/${accountAddr}`)
       if (res.ok) {
         const data = await res.json()
         const assets: StellarAsset[] = data.balances.map((b: any) => ({
@@ -161,7 +163,7 @@ export default function SwapPage() {
 
       const txBuilder = new TransactionBuilder(account, {
         fee: BASE_FEE,
-        networkPassphrase: Networks.TESTNET,
+        networkPassphrase: network.networkPassphrase,
       })
 
       // Auto-add trustline if needed so destination can receive the asset

--- a/frontend/wallet/app/token/[code]/page.tsx
+++ b/frontend/wallet/app/token/[code]/page.tsx
@@ -5,11 +5,14 @@ import { useRouter, useParams, useSearchParams } from 'next/navigation'
 import Image from 'next/image'
 import {
   Horizon, Keypair, rpc as SorobanRpc, Contract, Account,
-  TransactionBuilder, BASE_FEE, Networks, Asset, nativeToScVal, scValToNative,
+  TransactionBuilder, BASE_FEE, Asset, nativeToScVal, scValToNative,
 } from '@stellar/stellar-sdk'
 const Server = Horizon.Server
 import { TxDetailSheet, type TxRecord } from '@/components/TxDetailSheet'
 import { useInactivityLock } from '@/hooks/useInactivityLock'
+import { getNativeAssetContractId, getNetwork } from '@/lib/network'
+
+const network = getNetwork()
 
 // ── Token metadata ────────────────────────────────────────────────────────────
 const TOKEN_META: Record<string, { name: string; logo: string; color: string; bg: string }> = {
@@ -62,8 +65,6 @@ export default function TokenPage() {
   const [sparkPoints,  setSparkPoints]  = useState<number[]>([])
   const [priceChange,  setPriceChange]  = useState<number | null>(null)
 
-  const horizonUrl = 'https://horizon-testnet.stellar.org'
-
   const fetchData = useCallback(async () => {
     const signerSecret = sessionStorage.getItem('veil_signer_secret')
       ?? localStorage.getItem('veil_signer_secret')
@@ -79,7 +80,7 @@ export default function TokenPage() {
       signerPublicKey = storedPubKey
     }
     const walletAddress   = sessionStorage.getItem('invisible_wallet_address') ?? ''
-    const horizonServer   = new Server(horizonUrl)
+    const horizonServer   = new Server(network.horizonUrl)
 
     setLoading(true)
     try {
@@ -91,12 +92,12 @@ export default function TokenPage() {
 
         if (walletAddress) {
           try {
-            const rpcServer   = new SorobanRpc.Server('https://soroban-testnet.stellar.org')
-            const sacAddress  = Asset.native().contractId(Networks.TESTNET)
+            const rpcServer   = new SorobanRpc.Server(network.rpcUrl)
+            const sacAddress  = getNativeAssetContractId()
             const sacContract = new Contract(sacAddress)
             const dummyKp     = Keypair.random()
             const dummyAcct   = new Account(dummyKp.publicKey(), '0')
-            const balanceTx   = new TransactionBuilder(dummyAcct, { fee: BASE_FEE, networkPassphrase: Networks.TESTNET })
+            const balanceTx   = new TransactionBuilder(dummyAcct, { fee: BASE_FEE, networkPassphrase: network.networkPassphrase })
               .addOperation(sacContract.call('balance', nativeToScVal(walletAddress, { type: 'address' })))
               .setTimeout(30).build()
             const sim = await rpcServer.simulateTransaction(balanceTx)

--- a/frontend/wallet/components/WalletProvider.tsx
+++ b/frontend/wallet/components/WalletProvider.tsx
@@ -3,12 +3,7 @@
 import { createContext, useContext, useState, useCallback, ReactNode } from 'react'
 import { useInvisibleWallet } from '@veil/sdk'
 import { Keypair } from '@stellar/stellar-sdk'
-
-const TESTNET_CONFIG = {
-  rpcUrl: 'https://soroban-testnet.stellar.org',
-  networkPassphrase: 'Test SDF Network ; September 2015',
-  factoryAddress: process.env.NEXT_PUBLIC_FACTORY_CONTRACT_ID ?? '',
-}
+import { walletConfig } from '@/lib/network'
 
 interface WalletSession {
   address: string
@@ -27,7 +22,7 @@ const WalletContext = createContext<WalletContextValue | null>(null)
 export function WalletProvider({ children }: { children: ReactNode }) {
   const [session, setSessionState] = useState<WalletSession | null>(null)
 
-  const wallet = useInvisibleWallet(TESTNET_CONFIG)
+  const wallet = useInvisibleWallet(walletConfig)
 
   const setSession = useCallback((s: WalletSession | null) => {
     setSessionState(s)

--- a/frontend/wallet/lib/network.ts
+++ b/frontend/wallet/lib/network.ts
@@ -1,0 +1,66 @@
+import { Asset, Networks } from '@stellar/stellar-sdk'
+import type { WalletConfig } from '@veil/sdk'
+
+export type VeilNetworkName = 'testnet' | 'mainnet'
+
+export type VeilNetwork = {
+  name: VeilNetworkName
+  displayName: string
+  networkPassphrase: string
+  horizonUrl: string
+  rpcUrl: string
+  factoryContractId: string
+  friendbotUrl: string | null
+}
+
+export const NETWORKS: Record<VeilNetworkName, VeilNetwork> = {
+  testnet: {
+    name: 'testnet',
+    displayName: 'Stellar Testnet',
+    networkPassphrase: Networks.TESTNET,
+    horizonUrl: process.env.NEXT_PUBLIC_HORIZON_URL?.trim() || 'https://horizon-testnet.stellar.org',
+    rpcUrl:
+      process.env.NEXT_PUBLIC_SOROBAN_RPC_URL?.trim()
+      || process.env.NEXT_PUBLIC_RPC_URL?.trim()
+      || 'https://soroban-testnet.stellar.org',
+    factoryContractId:
+      process.env.NEXT_PUBLIC_FACTORY_CONTRACT_ID_TESTNET?.trim()
+      || process.env.NEXT_PUBLIC_FACTORY_CONTRACT_ID?.trim()
+      || '',
+    friendbotUrl: 'https://friendbot.stellar.org',
+  },
+  mainnet: {
+    name: 'mainnet',
+    displayName: 'Stellar Mainnet',
+    networkPassphrase: Networks.PUBLIC,
+    horizonUrl: 'https://horizon.stellar.org',
+    rpcUrl: process.env.NEXT_PUBLIC_MAINNET_RPC_URL?.trim() || '',
+    factoryContractId: process.env.NEXT_PUBLIC_FACTORY_CONTRACT_ID_MAINNET?.trim() || '',
+    friendbotUrl: null,
+  },
+}
+
+export function getNetwork(): VeilNetwork {
+  return process.env.NEXT_PUBLIC_NETWORK === 'mainnet'
+    ? NETWORKS.mainnet
+    : NETWORKS.testnet
+}
+
+export const walletConfig: WalletConfig = {
+  factoryAddress: getNetwork().factoryContractId,
+  rpcUrl: getNetwork().rpcUrl,
+  networkPassphrase: getNetwork().networkPassphrase,
+}
+
+export function getNativeAssetContractId(): string {
+  return Asset.native().contractId(getNetwork().networkPassphrase)
+}
+
+export function buildFriendbotUrl(address: string): string | null {
+  const friendbotUrl = getNetwork().friendbotUrl
+  if (!friendbotUrl) return null
+
+  const url = new URL(friendbotUrl)
+  url.searchParams.set('addr', address)
+  return url.toString()
+}


### PR DESCRIPTION
## Summary
Implements [issue #122](https://github.com/Miracle656/veil/issues/122): environment-aware Stellar network config (testnet + mainnet), centralizes Horizon / Soroban RPC / factory / Friendbot, guards testnet-only UI, and adds factory mainnet deployment docs.

## Changes
- **`frontend/wallet/lib/network.ts`** — single source of truth for `NEXT_PUBLIC_NETWORK` and related env vars
- **Wallet app** — replace hardcoded testnet URLs and `Networks.TESTNET` across dashboard, send, swap, lock, recover, token, settings, agent, and `WalletProvider`
- **Env** — `NEXT_PUBLIC_MAINNET_RPC_URL`, `NEXT_PUBLIC_FACTORY_CONTRACT_ID_TESTNET` / `MAINNET`, documented in root and wallet `.env.example`
- **`contracts/factory/DEPLOY.md`** — mainnet deploy steps (maintainer deploys; Wasm hash + CLI usage)

## Testing
- `NEXT_PUBLIC_NETWORK=testnet` and `mainnet` builds as expected
- Friendbot / “Fund wallet” only on testnet

Closes Miracle656/veil#122