### PR TITLE
feat(sdk): add optional OTLP tracing via tracing config option (#241)

### DIFF
--- a/sdk/package-lock.json
+++ b/sdk/package-lock.json
@@ -9,6 +9,9 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "@opentelemetry/api": "*",
+        "@opentelemetry/exporter-trace-otlp-http": "*",
+        "@opentelemetry/sdk-trace-base": "*",
         "@stellar/stellar-sdk": "^14.6.1"
       },
       "devDependencies": {
@@ -26,6 +29,11 @@
         "size-limit": "^12.1.0",
         "ts-jest": "^29.2.0",
         "typescript": "^5.0.0"
+      },
+      "optionalDependencies": {
+        "@opentelemetry/api": "*",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.218.0",
+        "@opentelemetry/sdk-trace-base": "^2.7.1"
       },
       "peerDependencies": {
         "react": ">=18.0.0",
@@ -76,6 +84,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1716,6 +1725,174 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.218.0.tgz",
+      "integrity": "sha512-fmEWp5kXlGEc3i/lR698Hz41DfGyN4Tbe4g7L1AxSc7fF8Xeh/FQ9Quqpa9dVA413Q1Ad43QOLzU4JoXgbFPWw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
+      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.218.0.tgz",
+      "integrity": "sha512-8dqezsmPhtKitIK/eTipZhYl9EX2/gNQ5zUMhaz3uxEURwfkNf8IPvo6yNfrzbxdtpAOybS/+h7wmIWYqFSpiw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/otlp-exporter-base": "0.218.0",
+        "@opentelemetry/otlp-transformer": "0.218.0",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/sdk-trace-base": "2.7.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.218.0.tgz",
+      "integrity": "sha512-ZwqpkNL5W7RyGJPDZ9g06DvKp8KFTWPJPN12anpMQYSKpTSU0z3EIZuPq9vPGpS8siFyOqDYDAuCwlNO9FqgbA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/otlp-transformer": "0.218.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.218.0.tgz",
+      "integrity": "sha512-CFaKH87WAzjuJ4awowTTLzUvMfaRfiOFG5+qm5S5ncyalRtN4ecQ+YmuANJSCrVPuvZFEkUgKhBPBndxi3rHsQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.218.0",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/sdk-logs": "0.218.0",
+        "@opentelemetry/sdk-metrics": "2.7.1",
+        "@opentelemetry/sdk-trace-base": "2.7.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
+      "integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.218.0.tgz",
+      "integrity": "sha512-QvnNdugatFTVCJXH0Mcu7GOOJSylA9j127kIezOE4YwTI4YbowRons2K4WZTv5FMS8T4q9P0NdaRHdkSmeAIag==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.218.0",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.7.1.tgz",
+      "integrity": "sha512-MpDJdkiFDs3Pm1RHO3KByuZbuBdJEXEAkiC0+yJdsZGVCdf1RpHR6n+LHDcS7ffmfrt5kVCzJSCfm4z2C7v0uQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.1.tgz",
+      "integrity": "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
+      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.10",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
@@ -1840,7 +2017,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -1861,7 +2037,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -1875,7 +2050,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -1890,8 +2064,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@testing-library/react": {
       "version": "16.3.2",
@@ -1936,8 +2109,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2067,6 +2239,7 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -2078,6 +2251,7 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -2243,7 +2417,6 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -2409,6 +2582,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2881,7 +3055,6 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -2911,8 +3084,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/domexception": {
       "version": "4.0.0",
@@ -3948,6 +4120,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -5402,7 +5575,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -5943,6 +6115,7 @@
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5956,6 +6129,7 @@
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -6183,6 +6357,7 @@
       "integrity": "sha512-VnDS2fycANrJFVPQwjaD+h+hkISY7EB3LsPsYWje4lBCjQwwsZLxjwwRwVJKHrcj2ZqyG+DdXykWm9mbZklZrw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bytes-iec": "^3.1.1",
         "lilconfig": "^3.1.3",
@@ -6420,6 +6595,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6618,6 +6794,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -108,5 +108,10 @@
       "path": "dist/vanilla.js",
       "limit": "225 KB"
     }
-  ]
+  ],
+  "optionalDependencies": {
+    "@opentelemetry/api": "*",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.218.0",
+    "@opentelemetry/sdk-trace-base": "^2.7.1"
+  }
 }

--- a/sdk/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/sdk/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -16,6 +16,7 @@ exports[`SDK API Surface should match the snapshot for main SDK exports 1`] = `
   "parseAuthData: function(arity: 1)",
   "parseClientDataJSON: function(arity: 1)",
   "sha256: function(arity: 1)",
+  "shutdownTracing: function(arity: 0)",
   "useInvisibleWallet: function(arity: 1)",
 ]
 `;

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -1,2 +1,4 @@
 export * from './useInvisibleWallet';
 export * from './utils';
+export type { TracingConfig } from './telemetry/tracing';
+export { shutdownTracing } from './telemetry/tracing';

--- a/sdk/src/telemetry/tracing.ts
+++ b/sdk/src/telemetry/tracing.ts
@@ -1,0 +1,165 @@
+/**
+ * sdk/src/telemetry/tracing.ts
+ *
+ * Optional OTLP tracing for the Veil SDK.
+ * Gated behind a `tracing: { exporter, endpoint }` SDK option.
+ * Defaults to a no-op — zero performance cost when not configured.
+ */
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export type TracingConfig = {
+    /** OTLP exporter type. Currently only 'otlp-http' is supported. */
+    exporter: 'otlp-http';
+    /** Full URL of your OTel collector endpoint, e.g. "http://localhost:4318/v1/traces" */
+    endpoint: string;
+};
+
+type SimpleSpan = {
+    setAttribute(key: string, value: string | number | boolean): void;
+    setStatus(status: { code: number; message?: string }): void;
+    recordException(err: Error): void;
+    end(): void;
+};
+
+// ── Internal state ────────────────────────────────────────────────────────────
+
+let _initialized = false;
+let _endpoint    = '';
+
+// ── Setup ─────────────────────────────────────────────────────────────────────
+
+export async function initTracing(config: TracingConfig): Promise<void> {
+    if (_initialized) return;
+    _initialized = true;
+    _endpoint    = config.endpoint;
+}
+
+// ── Span helpers ──────────────────────────────────────────────────────────────
+
+/**
+ * Wrap an async function in an OTLP trace span.
+ * If tracing is not configured, calls fn() directly with zero overhead.
+ */
+export async function withSpan<T>(
+    name: string,
+    attributes: Record<string, string | number | boolean>,
+    fn: (span: SimpleSpan) => Promise<T>
+): Promise<T> {
+    // No-op fast path
+    if (!_initialized || !_endpoint) {
+        const noopSpan: SimpleSpan = {
+            setAttribute: () => {},
+            setStatus:    () => {},
+            recordException: () => {},
+            end:          () => {},
+        };
+        return fn(noopSpan);
+    }
+
+    const traceId  = randomHex(16);
+    const spanId   = randomHex(8);
+    const start    = Date.now();
+    const spanAttrs = { ...attributes };
+    let   statusCode = 1; // OK
+    let   statusMsg  = '';
+    let   errorEvent: { name: string; message: string } | null = null;
+
+    const span: SimpleSpan = {
+        setAttribute(key, value) { spanAttrs[key] = value; },
+        setStatus({ code, message }) { statusCode = code; statusMsg = message ?? ''; },
+        recordException(err) { errorEvent = { name: err.name, message: err.message }; },
+        end() { /* flush handled after fn resolves */ },
+    };
+
+    try {
+        const result = await fn(span);
+        statusCode = 1; // OK
+        return result;
+    } catch (err: unknown) {
+        statusCode = 2; // ERROR
+        statusMsg  = err instanceof Error ? err.message : String(err);
+        if (err instanceof Error) errorEvent = { name: err.name, message: err.message };
+        throw err;
+    } finally {
+        const end = Date.now();
+        flush({
+            traceId, spanId, name, start, end,
+            attributes: spanAttrs, statusCode, statusMsg, errorEvent,
+        }).catch(() => { /* best-effort — never throw */ });
+    }
+}
+
+// ── OTLP HTTP flush ───────────────────────────────────────────────────────────
+
+type FlushArgs = {
+    traceId: string;
+    spanId: string;
+    name: string;
+    start: number;
+    end: number;
+    attributes: Record<string, string | number | boolean>;
+    statusCode: number;
+    statusMsg: string;
+    errorEvent: { name: string; message: string } | null;
+};
+
+async function flush(args: FlushArgs): Promise<void> {
+    const { traceId, spanId, name, start, end, attributes, statusCode, statusMsg, errorEvent } = args;
+
+    const kvAttrs = Object.entries(attributes).map(([key, value]) => ({
+        key,
+        value: typeof value === 'string'
+            ? { stringValue: value }
+            : typeof value === 'number'
+            ? { intValue: value }
+            : { boolValue: value },
+    }));
+
+    if (errorEvent) {
+        kvAttrs.push(
+            { key: 'exception.type',    value: { stringValue: errorEvent.name } },
+            { key: 'exception.message', value: { stringValue: errorEvent.message } },
+        );
+    }
+
+    const body = {
+        resourceSpans: [{
+            resource: { attributes: [{ key: 'service.name', value: { stringValue: 'invisible-wallet-sdk' } }] },
+            scopeSpans: [{
+                scope: { name: 'invisible-wallet-sdk', version: '0.1.0' },
+                spans: [{
+                    traceId,
+                    spanId,
+                    name,
+                    kind: 3, // CLIENT
+                    startTimeUnixNano: String(start * 1_000_000),
+                    endTimeUnixNano:   String(end   * 1_000_000),
+                    attributes: kvAttrs,
+                    status: { code: statusCode, message: statusMsg },
+                }],
+            }],
+        }],
+    };
+
+    await fetch(_endpoint, {
+        method:  'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body:    JSON.stringify(body),
+    });
+}
+
+// ── Shutdown ──────────────────────────────────────────────────────────────────
+
+export async function shutdownTracing(): Promise<void> {
+    _initialized = false;
+    _endpoint    = '';
+}
+
+// ── Utils ─────────────────────────────────────────────────────────────────────
+
+function randomHex(bytes: number): string {
+    const arr = new Uint8Array(bytes);
+    crypto.getRandomValues(arr);
+    return Array.from(arr).map(b => b.toString(16).padStart(2, '0')).join('');
+}

--- a/sdk/src/useInvisibleWallet.ts
+++ b/sdk/src/useInvisibleWallet.ts
@@ -13,6 +13,7 @@ import {
     Networks,
     hash as stellarHash,
 } from '@stellar/stellar-sdk';
+import { initTracing, withSpan, TracingConfig } from './telemetry/tracing';
 
 const HorizonServer = Horizon.Server;
 import {
@@ -64,6 +65,15 @@ export type WalletConfig = {
      * const config = { ..., storage: AsyncStorage };
      */
     storage?: StorageAdapter;
+    /**
+     * Optional OTLP tracing configuration.
+     * When provided, the SDK emits spans for the full payment lifecycle.
+     * Defaults to no-op — zero performance cost when not configured.
+     *
+     * @example
+     * tracing: { exporter: 'otlp-http', endpoint: 'http://localhost:4318/v1/traces' }
+     */
+    tracing?: TracingConfig;
 };
 
 /**
@@ -300,6 +310,13 @@ function resolveStorage(storage?: StorageAdapter): StorageAdapter {
 
 export function useInvisibleWallet(config: WalletConfig): InvisibleWallet {
     const { factoryAddress, rpcUrl, networkPassphrase, rpId, origin } = config;
+    // Initialize tracing once if configured — no-op if not provided
+    useEffect(() => {
+        if (config.tracing) {
+            initTracing(config.tracing);
+        }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     const [address, setAddress] = useState<string | null>(null);
     const [isDeployed, setIsDeployed] = useState(false);
@@ -322,46 +339,49 @@ export function useInvisibleWallet(config: WalletConfig): InvisibleWallet {
     }, []);
 
     // ── register ──────────────────────────────────────────────────────────────
+const register = useCallback(async (username?: string): Promise<RegisterResult> => {
+        return withSpan('veil.register', { 'wallet.username': username ?? 'anonymous' }, async (span) => {
+            setIsPending(true);
+            setError(null);
+            try {
+                const challenge = crypto.getRandomValues(new Uint8Array(32));
+                const name      = username || 'Veil User';
+                const userId    = username
+                    ? new TextEncoder().encode(username)
+                    : crypto.getRandomValues(new Uint8Array(16));
 
-    const register = useCallback(async (username?: string): Promise<RegisterResult> => {
-        setIsPending(true);
-        setError(null);
-        try {
-            const challenge = crypto.getRandomValues(new Uint8Array(32));
-            const name      = username || 'Veil User';
-            const userId    = username
-                ? new TextEncoder().encode(username)
-                : crypto.getRandomValues(new Uint8Array(16));
+                const resolvedRpId = rpId ?? (typeof window !== 'undefined' ? window.location.hostname : 'localhost');
 
-            const resolvedRpId = rpId ?? (typeof window !== 'undefined' ? window.location.hostname : 'localhost');
+                const { credentialId, publicKeyBytes } = await webAuthnProvider.create({
+                    challenge,
+                    rpId:     resolvedRpId,
+                    rpName:   'Invisible Wallet',
+                    userId,
+                    userName: name,
+                });
 
-            const { credentialId, publicKeyBytes } = await webAuthnProvider.create({
-                challenge,
-                rpId:     resolvedRpId,
-                rpName:   'Invisible Wallet',
-                userId,
-                userName: name,
-            });
+                const publicKeyHex  = bufferToHex(publicKeyBytes);
+                const walletAddress = computeWalletAddress(factoryAddress, publicKeyBytes, networkPassphrase);
 
-            const publicKeyHex  = bufferToHex(publicKeyBytes);
-            const walletAddress = computeWalletAddress(factoryAddress, publicKeyBytes, networkPassphrase);
+                await store.setItem('invisible_wallet_address',    walletAddress);
+                await store.setItem('invisible_wallet_key_id',     credentialId);
+                await store.setItem('invisible_wallet_public_key', publicKeyHex);
+                setAddress(walletAddress);
+                setIsDeployed(false);
 
-            await store.setItem('invisible_wallet_address',    walletAddress);
-            await store.setItem('invisible_wallet_key_id',     credentialId);
-            await store.setItem('invisible_wallet_public_key', publicKeyHex);
-            setAddress(walletAddress);
-            setIsDeployed(false);
+                span.setAttribute('wallet.address', walletAddress);
+                return { walletAddress, publicKeyBytes };
 
-            return { walletAddress, publicKeyBytes };
-
-        } catch (err: unknown) {
-            const message = err instanceof Error ? err.message : String(err);
-            setError(message);
-            throw err;
-        } finally {
-            setIsPending(false);
-        }
+            } catch (err: unknown) {
+                const message = err instanceof Error ? err.message : String(err);
+                setError(message);
+                throw err;
+            } finally {
+                setIsPending(false);
+            }
+        }); // end withSpan
     }, [factoryAddress, networkPassphrase, rpId, store]);
+    
 
     // ── deploy ────────────────────────────────────────────────────────────────
 
@@ -369,97 +389,103 @@ export function useInvisibleWallet(config: WalletConfig): InvisibleWallet {
         signerSecret: string | Keypair,
         publicKeyBytes?: Uint8Array
     ): Promise<DeployResult> => {
-        const signerKeypair = typeof signerSecret === 'string'
-            ? Keypair.fromSecret(signerSecret)
-            : Keypair.fromSecret(signerSecret.secret());
-        setIsPending(true);
-        setError(null);
-        let walletAddress: string | undefined;
-        try {
-            let pubKeyBytes = publicKeyBytes;
-            if (!pubKeyBytes) {
-                const hex = await store.getItem('invisible_wallet_public_key');
-                if (!hex) throw new Error(
-                    'No public key found. Call register() first, or pass publicKeyBytes explicitly.'
-                );
-                pubKeyBytes = hexToUint8Array(hex);
-            }
+        return withSpan('veil.deploy', { 'wallet.factory': factoryAddress }, async (span) => {
+            const signerKeypair = typeof signerSecret === 'string'
+                ? Keypair.fromSecret(signerSecret)
+                : Keypair.fromSecret(signerSecret.secret());
+            setIsPending(true);
+            setError(null);
+            let walletAddress: string | undefined;
+            try {
+                let pubKeyBytes = publicKeyBytes;
+                if (!pubKeyBytes) {
+                    const hex = await store.getItem('invisible_wallet_public_key');
+                    if (!hex) throw new Error(
+                        'No public key found. Call register() first, or pass publicKeyBytes explicitly.'
+                    );
+                    pubKeyBytes = hexToUint8Array(hex);
+                }
 
-            walletAddress = computeWalletAddress(factoryAddress, pubKeyBytes, networkPassphrase);
+                walletAddress = computeWalletAddress(factoryAddress, pubKeyBytes, networkPassphrase);
+                span.setAttribute('wallet.address', walletAddress);
 
-            const server = new SorobanRpc.Server(rpcUrl);
+                const server = new SorobanRpc.Server(rpcUrl);
 
-            const horizonUrl = networkPassphrase === Networks.TESTNET
-                ? 'https://horizon-testnet.stellar.org'
-                : 'https://horizon.stellar.org';
-            const horizon = new HorizonServer(horizonUrl);
-            const sourceAccount = await horizon.loadAccount(signerKeypair.publicKey());
-            const factory = new Contract(factoryAddress);
+                const horizonUrl = networkPassphrase === Networks.TESTNET
+                    ? 'https://horizon-testnet.stellar.org'
+                    : 'https://horizon.stellar.org';
+                const horizon = new HorizonServer(horizonUrl);
+                const sourceAccount = await horizon.loadAccount(signerKeypair.publicKey());
+                const factory = new Contract(factoryAddress);
 
-            const resolvedRpId  = rpId    ?? (typeof window !== 'undefined' ? window.location.hostname : 'localhost');
-            const resolvedOrigin = origin ?? (typeof window !== 'undefined' ? window.location.origin  : `https://${resolvedRpId}`);
+                const resolvedRpId  = rpId    ?? (typeof window !== 'undefined' ? window.location.hostname : 'localhost');
+                const resolvedOrigin = origin ?? (typeof window !== 'undefined' ? window.location.origin  : `https://${resolvedRpId}`);
 
-            const rpIdBytes   = new TextEncoder().encode(resolvedRpId);
-            const originBytes = new TextEncoder().encode(resolvedOrigin);
+                const rpIdBytes   = new TextEncoder().encode(resolvedRpId);
+                const originBytes = new TextEncoder().encode(resolvedOrigin);
 
-            const tx = new TransactionBuilder(sourceAccount, {
-                fee: BASE_FEE,
-                networkPassphrase,
-            })
-                .addOperation(
-                    factory.call(
-                        'deploy',
-                        nativeToScVal(pubKeyBytes,  { type: 'bytes' }),
-                        nativeToScVal(rpIdBytes,    { type: 'bytes' }),
-                        nativeToScVal(originBytes,  { type: 'bytes' }),
+                const tx = new TransactionBuilder(sourceAccount, {
+                    fee: BASE_FEE,
+                    networkPassphrase,
+                })
+                    .addOperation(
+                        factory.call(
+                            'deploy',
+                            nativeToScVal(pubKeyBytes,  { type: 'bytes' }),
+                            nativeToScVal(rpIdBytes,    { type: 'bytes' }),
+                            nativeToScVal(originBytes,  { type: 'bytes' }),
+                        )
                     )
-                )
-                .setTimeout(30)
-                .build();
+                    .setTimeout(30)
+                    .build();
 
-            const sim = await server.simulateTransaction(tx);
-            if (SorobanRpc.Api.isSimulationError(sim)) {
-                throw new Error(`Simulation failed: ${sim.error}`);
-            }
+                const sim = await server.simulateTransaction(tx);
+                if (SorobanRpc.Api.isSimulationError(sim)) {
+                    throw new Error(`Simulation failed: ${sim.error}`);
+                }
 
-            const assembled = SorobanRpc.assembleTransaction(tx, sim).build();
-            assembled.sign(signerKeypair);
+                const assembled = SorobanRpc.assembleTransaction(tx, sim).build();
+                assembled.sign(signerKeypair);
 
-            const sendResult = await server.sendTransaction(assembled);
-            if (sendResult.status === 'ERROR') {
-                throw new Error(
-                    `Transaction rejected: ${sendResult.errorResult?.toXDR('base64') ?? 'unknown error'}`
-                );
-            }
+                const sendResult = await server.sendTransaction(assembled);
+                if (sendResult.status === 'ERROR') {
+                    throw new Error(
+                        `Transaction rejected: ${sendResult.errorResult?.toXDR('base64') ?? 'unknown error'}`
+                    );
+                }
 
-            const txResult = await waitForTransaction(server, sendResult.hash);
-            if (txResult.status !== SorobanRpc.Api.GetTransactionStatus.SUCCESS) {
-                throw new Error(`Transaction failed with status: ${txResult.status}`);
-            }
+                const txResult = await waitForTransaction(server, sendResult.hash);
+                if (txResult.status !== SorobanRpc.Api.GetTransactionStatus.SUCCESS) {
+                    throw new Error(`Transaction failed with status: ${txResult.status}`);
+                }
 
-            setAddress(walletAddress);
-            setIsDeployed(true);
-            await store.setItem('invisible_wallet_address', walletAddress);
-            return { walletAddress, alreadyDeployed: false };
-
-        } catch (err: unknown) {
-            let message: string;
-            if (err instanceof Error) {
-                message = err.message;
-            } else {
-                try { message = JSON.stringify(err); } catch { message = String(err); }
-            }
-            if (message.toLowerCase().includes('alreadydeployed') || message.toLowerCase().includes('already_deployed')) {
-                setAddress(walletAddress!);
+                span.setAttribute('wallet.tx_hash', sendResult.hash);
+                span.setAttribute('wallet.already_deployed', false);
+                setAddress(walletAddress);
                 setIsDeployed(true);
-                await store.setItem('invisible_wallet_address', walletAddress!);
-                return { walletAddress: walletAddress!, alreadyDeployed: true };
+                await store.setItem('invisible_wallet_address', walletAddress);
+                return { walletAddress, alreadyDeployed: false };
+
+            } catch (err: unknown) {
+                let message: string;
+                if (err instanceof Error) {
+                    message = err.message;
+                } else {
+                    try { message = JSON.stringify(err); } catch { message = String(err); }
+                }
+                if (message.toLowerCase().includes('alreadydeployed') || message.toLowerCase().includes('already_deployed')) {
+                    span.setAttribute('wallet.already_deployed', true);
+                    setAddress(walletAddress!);
+                    setIsDeployed(true);
+                    await store.setItem('invisible_wallet_address', walletAddress!);
+                    return { walletAddress: walletAddress!, alreadyDeployed: true };
+                }
+                setError(message);
+                throw new Error(message);
+            } finally {
+                setIsPending(false);
             }
-            setError(message);
-            throw new Error(message);
-        } finally {
-            setIsPending(false);
-        }
+        }); // end withSpan
     }, [factoryAddress, rpcUrl, networkPassphrase, rpId, origin, store]);
 
     // ── login ─────────────────────────────────────────────────────────────────
@@ -509,39 +535,42 @@ export function useInvisibleWallet(config: WalletConfig): InvisibleWallet {
     const signAuthEntry = useCallback(async (
         signaturePayload: Uint8Array
     ): Promise<WebAuthnSignature | null> => {
-        setIsPending(true);
-        setError(null);
-        try {
-            const keyId        = await store.getItem('invisible_wallet_key_id');
-            const publicKeyHex = await store.getItem('invisible_wallet_public_key');
-            if (!keyId)        throw new Error('No key ID found. Please register first.');
-            if (!publicKeyHex) throw new Error('No public key found. Please register first.');
+        return withSpan('veil.signAuthEntry', { 'wallet.payload_size': signaturePayload.length }, async (span) => {
+            setIsPending(true);
+            setError(null);
+            try {
+                const keyId        = await store.getItem('invisible_wallet_key_id');
+                const publicKeyHex = await store.getItem('invisible_wallet_public_key');
+                if (!keyId)        throw new Error('No key ID found. Please register first.');
+                if (!publicKeyHex) throw new Error('No public key found. Please register first.');
 
-            if (signaturePayload.length !== 32) {
-                throw new Error('signaturePayload must be exactly 32 bytes');
+                if (signaturePayload.length !== 32) {
+                    throw new Error('signaturePayload must be exactly 32 bytes');
+                }
+
+                const challenge = signaturePayload.buffer.slice(
+                    signaturePayload.byteOffset,
+                    signaturePayload.byteOffset + signaturePayload.byteLength
+                ) as ArrayBuffer;
+
+                const { authData, clientDataJSON, signature } = await webAuthnProvider.authenticate({
+                    challenge,
+                    credentialId: keyId,
+                    rpId,
+                });
+
+                const publicKeyBytes = hexToUint8Array(publicKeyHex);
+
+                span.setAttribute('wallet.key_id', keyId);
+                return { publicKey: publicKeyBytes, authData, clientDataJSON, signature };
+
+            } catch (err: unknown) {
+                setError(err instanceof Error ? err.message : String(err));
+                throw err;
+            } finally {
+                setIsPending(false);
             }
-
-            const challenge = signaturePayload.buffer.slice(
-                signaturePayload.byteOffset,
-                signaturePayload.byteOffset + signaturePayload.byteLength
-            ) as ArrayBuffer;
-
-            const { authData, clientDataJSON, signature } = await webAuthnProvider.authenticate({
-                challenge,
-                credentialId: keyId,
-                rpId,
-            });
-
-            const publicKeyBytes = hexToUint8Array(publicKeyHex);
-
-            return { publicKey: publicKeyBytes, authData, clientDataJSON, signature };
-
-        } catch (err: unknown) {
-            setError(err instanceof Error ? err.message : String(err));
-            throw err;
-        } finally {
-            setIsPending(false);
-        }
+        }); // end withSpan
     }, [rpId, store]);
 
     // ── getNonce ──────────────────────────────────────────────────────────────


### PR DESCRIPTION

## Summary
Implements #241 — optional OTLP tracing for SDK consumers self-hosting an OTel collector.

## Changes
- `sdk/src/telemetry/tracing.ts` (new) — no-op tracer by default, OTLP/HTTP flush when configured
- `sdk/src/useInvisibleWallet.ts` — added `tracing` option to `WalletConfig`, wraps `register`, `deploy`, and `signAuthEntry` with spans
- `sdk/src/index.ts` — exports `TracingConfig` type and `shutdownTracing`
- `sdk/package.json` — adds OTel packages as optional dependencies

## Usage
```ts
const wallet = useInvisibleWallet({
  factoryAddress: FACTORY_CONTRACT_ID,
  rpcUrl: 'https://soroban-testnet.stellar.org',
  networkPassphrase: Networks.TESTNET,
  tracing: {
    exporter: 'otlp-http',
    endpoint: 'http://localhost:4318/v1/traces',
  },
});
```

## Acceptance criteria
- [x] Default off, no perf cost — no-op path has zero overhead when `tracing` is not configured
- [x] When on, traces full payment lifecycle — spans cover `veil.register`, `veil.deploy`, `veil.signAuthEntry`
Closes #241