### PR TITLE
docs: add SECURITY.md, conventional-changelog script, SDK error refer…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to Veil are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+New sections are generated automatically by `conventional-changelog-cli` — run `npm run release-notes` from the repo root after tagging a release. See [CONTRIBUTING.md](CONTRIBUTING.md#generating-release-notes) for details.
 
 ## [Unreleased]
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,6 +113,43 @@ CI will run these on every PR — see `.github/workflows/ci.yml`.
 3. Open a draft PR early so we can give feedback as you go
 4. Mark ready for review when CI is green
 
+## Generating release notes
+
+`CHANGELOG.md` is updated automatically from commit messages via [`conventional-changelog-cli`](https://github.com/conventional-changelog/conventional-changelog).
+
+### Setup
+
+Install the root dev dependencies if you haven't already:
+
+```bash
+npm install
+```
+
+### Running the script
+
+After tagging a release (e.g. `git tag v0.2.0`), run from the repo root:
+
+```bash
+npm run release-notes
+```
+
+This prepends a new versioned section to `CHANGELOG.md` using the `angular` preset, which maps conventional-commit types to changelog categories:
+
+| Commit type | Changelog section |
+|---|---|
+| `feat` | Features |
+| `fix` | Bug Fixes |
+| `perf` | Performance Improvements |
+| `revert` | Reverts |
+| `docs`, `style`, `chore`, `test` | omitted by default |
+
+The script is defined in root `package.json` as:
+```json
+"release-notes": "conventional-changelog -p angular -i CHANGELOG.md -s"
+```
+
+Commit all changes to `CHANGELOG.md` as part of the release commit before pushing the tag.
+
 ## Questions
 
 Open a [discussion](https://github.com/Miracle656/veil/discussions) or comment on an existing issue. We're friendly.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,103 @@
+# Security Policy
+
+## Supported Versions
+
+Only the most recent release receives security patches. Veil is currently in testnet preview; no version is considered production-ready for Mainnet.
+
+| Version | Status          | Supported |
+|---------|-----------------|-----------|
+| 0.1.x   | Testnet preview | Yes       |
+| < 0.1   | —               | No        |
+
+Once a v1.0 release is cut, the table will track the current stable branch and the one prior minor version.
+
+---
+
+## Reporting a Vulnerability
+
+**Do not open a public GitHub issue for security reports.** Doing so discloses the vulnerability before a fix is available.
+
+### Preferred channel
+
+Email **security@invisible-wallet.dev** with:
+
+- A description of the vulnerability and its potential impact
+- Step-by-step reproduction instructions
+- The affected component(s): contract, SDK, wallet front-end, or agent
+- The affected version(s) or commit range
+- Any suggested mitigations you have identified
+
+PGP-encrypted email is accepted. Request the public key by emailing the address above with subject line `PGP key request` — we will respond with the key before you send sensitive details.
+
+### Backup channel
+
+GitHub's [private vulnerability reporting](https://github.com/Miracle656/veil/security/advisories/new) is also available and preferred when you do not need end-to-end encryption.
+
+---
+
+## Response SLA
+
+| Severity     | Acknowledgement | Triage complete | Fix target |
+|--------------|-----------------|-----------------|------------|
+| Critical     | 24 hours        | 48 hours        | 7 days     |
+| High         | 48 hours        | 5 days          | 14 days    |
+| Medium / Low | 72 hours        | 10 days         | 30 days    |
+
+Severity is assessed using [CVSS v3.1](https://www.first.org/cvss/calculator/3-1). We reserve the right to adjust timelines if the fix requires a coordinated release with an upstream dependency (Stellar SDK, Soroban runtime).
+
+---
+
+## Disclosure Policy
+
+We follow a coordinated disclosure model:
+
+1. Reporter submits the vulnerability privately.
+2. We acknowledge receipt and begin triage.
+3. We develop and test a fix on a private branch.
+4. We issue a patched release and publish a GitHub Security Advisory.
+5. After the advisory is public (minimum 7 days after the patch ships) the reporter may publish their own write-up.
+
+We will credit reporters by name or handle in the advisory unless they request anonymity.
+
+---
+
+## Safe Harbor
+
+We consider security research conducted under this policy to be authorized access. We will not initiate legal action against researchers who:
+
+- Act in good faith and follow this policy
+- Avoid accessing or modifying user data beyond what is required to demonstrate the vulnerability
+- Do not perform denial-of-service attacks
+- Do not exploit the vulnerability beyond a minimal proof of concept
+- Disclose findings to us before publishing
+
+This safe-harbor statement does not extend to activities that violate applicable law independent of this policy.
+
+---
+
+## Scope
+
+| In scope | Out of scope |
+|---|---|
+| `contracts/` — Soroban smart contracts | Third-party dependencies (Stellar Core, Horizon) |
+| `sdk/` — TypeScript client SDK | Phishing or social-engineering attacks |
+| `frontend/wallet/` — Next.js PWA | Physical access attacks |
+| `packages/agent/` — AI agent | Issues already publicly known |
+| `frontend/docs/` — documentation site | Stellar network-level issues |
+
+---
+
+## Out-of-Scope Vulnerabilities
+
+The following will not be accepted as valid reports:
+
+- Self-XSS requiring the user to run attacker-supplied JavaScript in their own browser console
+- Clickjacking on pages without sensitive actions
+- Missing `Strict-Transport-Security` or similar headers on development/preview deployments
+- Rate limiting on non-authenticated endpoints
+
+---
+
+## Audit Status
+
+No third-party audit has been completed. Veil is testnet-only. A full audit is planned before any Mainnet deployment. See the [Security](https://veil-2ap8.vercel.app/security) docs page for the current audit roadmap.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,35 @@
+version: "3.8"
+
+# Local Stellar development network — Stellar Core + Horizon + Soroban RPC bundled
+# via the official stellar/quickstart image.
+#
+# Usage:
+#   docker compose -f docker-compose.dev.yml up
+#
+# Horizon API:   http://localhost:8000
+# Soroban RPC:   http://localhost:8000/soroban/rpc
+# Friendbot:     http://localhost:8000/friendbot?addr=<G-address>
+
+services:
+  stellar:
+    image: stellar/quickstart:latest
+    platform: linux/amd64
+    ports:
+      - "8000:8000"
+    environment:
+      # Run as a standalone local network with a deterministic genesis ledger
+      - NETWORK=local
+    command: --local --enable-soroban-rpc
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "curl",
+          "--silent",
+          "--fail",
+          "http://localhost:8000/health"
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 30s

--- a/frontend/docs/pages/_meta.ts
+++ b/frontend/docs/pages/_meta.ts
@@ -1,9 +1,11 @@
 export default {
   index: 'Introduction',
   'getting-started': 'Getting Started',
+  'local-dev': 'Local Dev Emulator',
   architecture: 'Architecture',
   'contract-api': 'Contract API',
   'sdk-reference': 'SDK Reference',
+  'sdk-errors': 'SDK Error Reference',
   troubleshooting: 'Troubleshooting',
   'agent-integration': 'Agent Integration',
   security: 'Security',

--- a/frontend/docs/pages/local-dev.mdx
+++ b/frontend/docs/pages/local-dev.mdx
@@ -1,0 +1,182 @@
+---
+title: Local Dev Emulator
+description: Run a local Stellar network with Soroban RPC, deploy the wallet contract, and run a smoke test — all in one command.
+---
+
+import { Callout, Steps } from 'nextra/components'
+
+# Local Dev Emulator
+
+This guide sets up a self-contained local Stellar network so you can build and test Veil without touching Testnet. Everything runs in Docker: Stellar Core, Horizon, and the Soroban RPC server are bundled in the official `stellar/quickstart` image.
+
+<Callout type="info">
+  The local network resets every time the container restarts. All deployed contracts and funded accounts are lost. Use Testnet for persistence across sessions.
+</Callout>
+
+---
+
+## Prerequisites
+
+- [Docker Desktop](https://www.docker.com/products/docker-desktop/) 24+ (or Docker Engine + Compose plugin)
+- [Stellar CLI](https://developers.stellar.org/docs/tools/developer-tools/stellar-cli) (`stellar`) v21+
+- Rust with the `wasm32-unknown-unknown` target
+- Node.js 20+
+
+---
+
+## Start the local network
+
+<Steps>
+
+### Bring up the stack
+
+From the repo root:
+
+```bash
+docker compose -f docker-compose.dev.yml up
+```
+
+The container exposes:
+
+| Endpoint | URL |
+|---|---|
+| Horizon API | `http://localhost:8000` |
+| Soroban RPC | `http://localhost:8000/soroban/rpc` |
+| Friendbot | `http://localhost:8000/friendbot?addr=<G-address>` |
+
+### Wait for the healthcheck
+
+The container is ready when `docker compose -f docker-compose.dev.yml ps` shows `healthy`. You can also poll directly:
+
+```bash
+curl --silent http://localhost:8000/health
+# expected: {"status":"healthy"}
+```
+
+It typically takes 20–40 seconds for Stellar Core to reach consensus on the first ledger.
+
+</Steps>
+
+---
+
+## Configure the Stellar CLI
+
+Point the CLI at your local node:
+
+```bash
+stellar network add local \
+  --rpc-url http://localhost:8000/soroban/rpc \
+  --network-passphrase "Standalone Network ; February 2017"
+```
+
+Generate a funded test keypair using Friendbot:
+
+```bash
+# Generate a key
+stellar keys generate alice --network local
+
+# Fund it via Friendbot
+ALICE_ADDRESS=$(stellar keys address alice)
+curl "http://localhost:8000/friendbot?addr=${ALICE_ADDRESS}"
+
+# Verify balance
+stellar query account "${ALICE_ADDRESS}" --network local
+```
+
+---
+
+## Build and deploy the wallet contract
+
+```bash
+# Build WASM
+cd contracts/invisible_wallet
+cargo build --target wasm32-unknown-unknown --release
+
+# Deploy the factory contract
+stellar contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/factory.wasm \
+  --source alice \
+  --network local
+```
+
+The deploy command prints the factory contract address (`C...`). Save it — you will need it in the SDK config.
+
+---
+
+## First contract smoke test
+
+The repo includes a smoke test script that registers a simulated passkey, deploys a wallet via the factory, and submits a self-transfer:
+
+```bash
+# From repo root
+FACTORY_ADDRESS=<address from deploy step above> \
+  RPC_URL=http://localhost:8000/soroban/rpc \
+  NETWORK_PASSPHRASE="Standalone Network ; February 2017" \
+  npm run smoke
+```
+
+A successful run prints:
+
+```
+[smoke] wallet deployed at C...
+[smoke] transfer submitted — tx hash: a1b2c3...
+[smoke] all checks passed
+```
+
+If the smoke test fails, check `docker compose -f docker-compose.dev.yml logs stellar` for Soroban diagnostic events.
+
+---
+
+## Stopping the network
+
+```bash
+docker compose -f docker-compose.dev.yml down
+```
+
+Add `-v` to also remove the volume and get a clean slate on next start:
+
+```bash
+docker compose -f docker-compose.dev.yml down -v
+```
+
+---
+
+## Connecting the wallet front-end
+
+Once the local network is running, set the following environment variables before starting the Next.js dev server:
+
+```bash
+# frontend/wallet/.env.local
+NEXT_PUBLIC_RPC_URL=http://localhost:8000/soroban/rpc
+NEXT_PUBLIC_NETWORK_PASSPHRASE="Standalone Network ; February 2017"
+NEXT_PUBLIC_FACTORY_ADDRESS=<your deployed factory address>
+```
+
+Then:
+
+```bash
+cd frontend/wallet
+npm run dev
+```
+
+Open `http://localhost:3000`. WebAuthn works on `localhost` without HTTPS.
+
+---
+
+## Troubleshooting
+
+### `curl: (7) Failed to connect to localhost port 8000`
+
+The container is still starting. Wait for the healthcheck to pass — it can take up to 60 seconds on the first run while the image downloads.
+
+### `Error: stellar-core is not yet synced`
+
+Stellar Core needs a few ledgers to initialize on a fresh start. Wait 30 seconds and retry.
+
+### Soroban RPC returns `{"error":{"code":-32600}}`
+
+Your request body is malformed or using the wrong JSON-RPC envelope. Verify `RPC_URL` ends with `/soroban/rpc` (not `/`).
+
+### Friendbot returns `{"detail":"createAccountAlreadyExist"}`
+
+The account is already funded. This is not an error — the account exists and has a balance.

--- a/frontend/docs/pages/sdk-errors.mdx
+++ b/frontend/docs/pages/sdk-errors.mdx
@@ -1,0 +1,130 @@
+---
+title: SDK Error Reference
+description: Every error class and contract error code thrown by the Veil SDK, with causes and recovery guidance.
+---
+
+import { Callout } from 'nextra/components'
+
+# SDK Error Reference
+
+The Veil SDK and the underlying Soroban wallet contract produce typed errors. This page enumerates every error class and contract error code, when each is thrown, and how to recover.
+
+---
+
+## TypeScript SDK errors
+
+These classes are thrown by methods in `invisible-wallet-sdk`. They extend the native `Error` class, so you can catch them with a standard `try/catch` and narrow by `instanceof` or by the `.name` property.
+
+### `NoGuardianSet`
+
+| Property | Value |
+|---|---|
+| `name` | `"NoGuardianSet"` |
+| Message | `"No guardian has been set for this wallet"` |
+
+**When thrown:** You called `initiateRecovery()` or `completeRecovery()` on a wallet that was never configured with a guardian key via `setGuardian()`.
+
+**Recovery:** Register a guardian before initiating recovery. If you are already locked out and no guardian was ever set, there is no programmatic recovery path — the wallet contract is inaccessible.
+
+```typescript
+import { NoGuardianSet } from 'invisible-wallet-sdk'
+
+try {
+  await wallet.initiateRecovery(guardianKeypair)
+} catch (err) {
+  if (err instanceof NoGuardianSet) {
+    // prompt user to set a guardian before this flow is reachable
+  }
+}
+```
+
+---
+
+### `RecoveryTimelockActive`
+
+| Property | Value |
+|---|---|
+| `name` | `"RecoveryTimelockActive"` |
+| Constructor | `new RecoveryTimelockActive(expiresAt: number)` |
+| Message | `"Recovery timelock is active until <ISO 8601 date>"` |
+
+**When thrown:** You called `completeRecovery()` before the on-chain timelock has expired. The `expiresAt` Unix timestamp (seconds) is the earliest time the recovery can be completed.
+
+**Recovery:** Wait until `expiresAt` and retry. Display the expiry time to the user so they know when to return.
+
+```typescript
+import { RecoveryTimelockActive } from 'invisible-wallet-sdk'
+
+try {
+  await wallet.completeRecovery(newPublicKey, guardianKeypair)
+} catch (err) {
+  if (err instanceof RecoveryTimelockActive) {
+    const unlockDate = new Date(err.message.split('until ')[1])
+    console.log(`Try again after ${unlockDate.toLocaleString()}`)
+  }
+}
+```
+
+---
+
+### `RecoveryNotPending`
+
+| Property | Value |
+|---|---|
+| `name` | `"RecoveryNotPending"` |
+| Message | `"No recovery is currently pending"` |
+
+**When thrown:** You called `completeRecovery()` but no recovery was ever initiated for this wallet, or a previous recovery was already completed or cancelled.
+
+**Recovery:** Call `initiateRecovery()` first to start a new recovery window, then wait for the timelock to expire before calling `completeRecovery()`.
+
+---
+
+## Contract error codes (`WalletError`)
+
+The `WalletError` enum is defined in `contracts/invisible_wallet/src/lib.rs`. When a Soroban invocation fails with one of these codes the SDK wraps it in a standard `Error` whose message contains the numeric code returned by the RPC node.
+
+| Code | Name | When thrown | Recovery |
+|------|------|-------------|----------|
+| 1 | `AlreadyInitialized` | `init()` called on a wallet that already has a registered signer | Do not call `init()` more than once per contract instance |
+| 2 | `InvalidSignatureFormat` | The WebAuthn signature bytes could not be parsed as DER-encoded ECDSA | Ensure `derToRawSignature` in `utils.ts` ran without error before submitting |
+| 3 | `SignerNotAuthorized` | The supplied public key is not in the registered-signers list | Register the key via `add_signer()` using an already-authorized signer |
+| 4 | `InvalidPublicKey` | The supplied public key bytes are not a valid uncompressed P-256 point (must be 65 bytes, prefix `0x04`) | Re-extract the key with `extractP256PublicKey` |
+| 5 | `InvalidSignature` | The signature bytes are not valid (wrong length, malformed `r`/`s`) | Re-run `derToRawSignature`; check the raw byte length is 64 |
+| 6 | `SignatureVerificationFailed` | P-256 ECDSA verification failed — signature does not match the payload under the supplied key | The WebAuthn assertion was for a different transaction; re-request a fresh assertion |
+| 7 | `InvalidChallenge` | `challenge` is absent from `clientDataJSON` or does not match `base64url(signature_payload)` | Ensure the challenge passed to `navigator.credentials.get()` is `base64url(signature_payload)` with no padding |
+| 8 | `RpIdMismatch` | `rpIdHash` in `authData` does not match `SHA-256(expected_rp_id)` stored in the contract | The credential was registered for a different domain; register a new credential on the correct origin |
+| 9 | `OriginMismatch` | `origin` in `clientDataJSON` does not match the expected origin | The assertion came from the wrong website; ensure your app URL matches the registered RP ID |
+| 10 | `CannotRemoveLastSigner` | `remove_signer()` would leave the wallet with zero signers | Add a replacement signer before removing the last one |
+| 11 | `SignerNotFound` | The signer index supplied to `remove_signer()` does not exist | Query the current signer list before removing |
+| 12 | `NoGuardianSet` | `initiate_recovery()` called but no guardian was registered via `set_guardian()` | Register a guardian first |
+| 13 | `RecoveryAlreadyPending` | `initiate_recovery()` called while a recovery is already in progress | Cancel the existing recovery or wait for it to complete |
+| 14 | `RecoveryNotPending` | `complete_recovery()` called with no active recovery | Call `initiate_recovery()` first |
+| 15 | `RecoveryTimelockActive` | `complete_recovery()` called before the timelock has expired | Wait for the on-chain ledger timestamp to exceed the stored expiry |
+| 16 | `NonceMismatch` | The transaction nonce is out of sequence (replay or ordering protection) | Fetch the current on-chain nonce and retry with the correct value |
+| 17 | `InsufficientAllowance` | A session-key transfer exceeds its approved spending limit | Request a new session key with a higher allowance, or use the primary passkey signer |
+| 18 | `AllowanceExpired` | The session-key allowance period has ended | Issue a new session key |
+| 19 | `SessionKeyExpired` | The session key's validity window has passed | Issue a new session key |
+| 20 | `SessionKeyAclViolation` | The session key attempted an operation not permitted by its ACL | Use a session key with broader permissions, or use the primary passkey signer |
+
+---
+
+## Mapping contract codes to SDK errors
+
+When the Soroban RPC returns a simulation or transaction failure the error object contains a `diagnosticEvents` array. The contract code is embedded as a `u32` in the event data. The SDK does not currently re-wrap these into typed classes; callers must inspect the raw RPC error. A future SDK release will expose a helper:
+
+```typescript
+// Planned (not yet released)
+import { parseContractError } from 'invisible-wallet-sdk'
+
+try {
+  await wallet.send(destination, amount, signerKeypair)
+} catch (err) {
+  const code = parseContractError(err) // returns WalletError code or null
+  if (code === 6) { /* SignatureVerificationFailed — re-request assertion */ }
+}
+```
+
+<Callout type="info">
+  Until `parseContractError` ships, inspect `err.message` for the string `"Error(Contract, #N)"` where `N` is the numeric code from the table above.
+</Callout>

--- a/package.json
+++ b/package.json
@@ -2,13 +2,15 @@
   "private": true,
   "description": "Root scripts — smoke tests and tooling for Veil",
   "scripts": {
-    "smoke": "npx ts-node scripts/smoke_test.ts"
+    "smoke": "npx ts-node scripts/smoke_test.ts",
+    "release-notes": "conventional-changelog -p angular -i CHANGELOG.md -s"
   },
   "dependencies": {
     "@stellar/stellar-sdk": "^14.6.1"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
+    "conventional-changelog-cli": "^4.1.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.4.0"
   }


### PR DESCRIPTION
## Summary

- Adds `SECURITY.md` with a supported-versions table, encrypted-email and GitHub private-advisory reporting channels, severity-based SLA targets, coordinated-disclosure timeline, safe-harbor language, and in-scope/out-of-scope tables (closes #272)
- Wires `conventional-changelog-cli` into a `release-notes` npm script in root `package.json` that prepends a new versioned section to `CHANGELOG.md` on each tag; documents the workflow in a new `CONTRIBUTING.md` section (closes #271)
- Adds `frontend/docs/pages/sdk-errors.mdx` covering all three TypeScript SDK error classes (`NoGuardianSet`, `RecoveryTimelockActive`, `RecoveryNotPending`) with `instanceof` catch examples, and all 20 `WalletError` contract codes with causes and recovery steps; registers the page in `_meta.ts` (closes #270)
- Adds `docker-compose.dev.yml` using the official `stellar/quickstart` image with Soroban RPC enabled and a Docker healthcheck; adds `frontend/docs/pages/local-dev.mdx` covering startup, CLI configuration, Friendbot funding, contract build and deploy, smoke-test invocation, front-end wiring, and common troubleshooting cases; registers the page in `_meta.ts` (closes #269)

## Test plan

- [ ] `SECURITY.md` renders in the GitHub Security tab (Settings > Security > Policy)
- [ ] `npm install && npm run release-notes` from repo root exits 0 and prepends a new section to `CHANGELOG.md`
- [ ] `docker compose -f docker-compose.dev.yml up` reaches `healthy` status and `curl http://localhost:8000/health` returns `{"status":"healthy"}`
- [ ] `npm run smoke` (with env vars set) passes against the local network
- [ ] Docs site builds without error: `cd frontend/docs && npm run build`
- [ ] `sdk-errors` and `local-dev` pages appear in the docs sidebar
