### PR TITLE
Feat/wave advanced 279 282

### DIFF
--- a/.github/workflows/reproducible-build.yml
+++ b/.github/workflows/reproducible-build.yml
@@ -1,0 +1,44 @@
+name: Reproducible build
+
+# Verifies that the Soroban contract WASM is built deterministically and that
+# its SHA-256 matches the committed contracts/expected-hashes.json. This lets a
+# third party confirm a deployed contract hash was produced from this source.
+#
+# The build runs inside the pinned rust:1.85.0-bookworm image with the repo
+# mounted at a fixed path (/work), exactly as scripts/reproducible-build.sh does
+# locally — so hashes produced here match hashes produced on any other machine.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  reproducible-build:
+    name: Reproducible WASM build & hash verification
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Acceptance: CI fails if the build drifts from the committed hash.
+      - name: Build & verify against committed hashes
+        run: scripts/reproducible-build.sh
+
+      # Acceptance: deterministic build — the same source yields the same hash
+      # across two independent builds. We regenerate the hash document twice and
+      # assert the two are byte-identical.
+      - name: Determinism — build twice and compare
+        run: |
+          set -euo pipefail
+          cp contracts/expected-hashes.json /tmp/run-1.json
+          rm -f contracts/expected-hashes.json
+          scripts/reproducible-build.sh --update
+          cp contracts/expected-hashes.json /tmp/run-2.json
+          # Restore the committed file so the working tree stays clean.
+          git checkout -- contracts/expected-hashes.json
+          if ! diff -u /tmp/run-1.json /tmp/run-2.json; then
+            echo "::error::Non-deterministic build — two runs produced different hashes." >&2
+            exit 1
+          fi
+          echo "Build is deterministic: both runs produced identical hashes."

--- a/README.md
+++ b/README.md
@@ -384,6 +384,13 @@ The contract's `__check_auth` expects the signature field to be a `Vec<Val>` wit
 
 See the [Security docs](https://veil-2ap8.vercel.app/security) and the [Threat Model](https://veil-2ap8.vercel.app/threat-model) for the full STRIDE analysis, trust assumptions, and residual risks.
 
+### Verifying contract builds
+
+The Soroban contracts build reproducibly, so you can confirm a deployed contract
+hash was produced from this source. With Docker installed, run
+`scripts/reproducible-build.sh` to rebuild and compare against the committed
+`contracts/expected-hashes.json`. See [docs/reproducible-build.md](docs/reproducible-build.md).
+
 ## License
 
 MIT

--- a/contracts/expected-hashes.json
+++ b/contracts/expected-hashes.json
@@ -1,0 +1,11 @@
+{
+  "_comment": "SHA-256 of release wasm artifacts. Regenerate with scripts/reproducible-build.sh --update.",
+  "artifacts": {
+    "factory.wasm": "1ad31fc22fb7d17d3698d887d51e3b99d1de0d4a4c39275fa76c7524e126d296",
+    "invisible_wallet.wasm": "80fa7d8ec38c54c41a7528dd83266decc1962ed26a456c3cb8fb37c73b841304",
+    "mock_wallet.wasm": "c86f7ccbdcc54674c0d428eed7bce81699d946fe3af21e78ca4d22e88ed73f1a"
+  },
+  "image": "rust:1.85.0-bookworm",
+  "target": "wasm32-unknown-unknown",
+  "toolchain": "1.85.0"
+}

--- a/docs/reproducible-build.md
+++ b/docs/reproducible-build.md
@@ -1,0 +1,59 @@
+# Reproducible contract builds
+
+Veil's Soroban contracts are built deterministically so that **anyone can verify
+a deployed contract hash was produced from this public source** — no trust in
+the maintainers' build machine required.
+
+## How it works
+
+The build is pinned along every axis that can affect the output bytes:
+
+- **Toolchain** — `contracts/rust-toolchain.toml` pins Rust to `1.85.0`.
+- **Dependencies** — `contracts/Cargo.lock` is built with `--locked`.
+- **Environment & paths** — the build runs inside the
+  `rust:1.85.0-bookworm` Docker image with the repository mounted at a fixed
+  path (`/work`) and a fixed `CARGO_HOME`, so the absolute paths `rustc` embeds
+  are identical on every machine, including CI.
+
+Because all of these are fixed, the release `.wasm` artifacts — and therefore
+their SHA-256 hashes — are byte-identical across machines. The expected hashes
+are committed in [`contracts/expected-hashes.json`](../contracts/expected-hashes.json).
+
+## Verify it yourself
+
+You need Docker installed. From the repository root:
+
+```bash
+scripts/reproducible-build.sh
+```
+
+This builds the contracts in the pinned image, hashes the resulting `.wasm`
+artifacts, and compares them against `contracts/expected-hashes.json`. It exits
+non-zero if any hash drifts.
+
+To build against the host toolchain instead of Docker (must match
+`rust-toolchain.toml`):
+
+```bash
+scripts/reproducible-build.sh --no-docker
+```
+
+## Updating the expected hashes
+
+When a contract change intentionally alters the WASM, regenerate the committed
+hashes and commit the result:
+
+```bash
+scripts/reproducible-build.sh --update
+git add contracts/expected-hashes.json
+```
+
+## CI
+
+The [`reproducible-build`](../.github/workflows/reproducible-build.yml) workflow
+runs on every push and pull request to `main`. It:
+
+1. Builds and verifies the WASM hashes against the committed values — failing
+   the job on any drift.
+2. Builds a second time and asserts the two runs produce identical hashes,
+   proving the build is deterministic.

--- a/frontend/wallet/lib/recovery.ts
+++ b/frontend/wallet/lib/recovery.ts
@@ -3,6 +3,14 @@ import { wordlist } from '@scure/bip39/wordlists/english';
 import { p256 } from '@noble/curves/nist';
 import { sha256 } from '@noble/hashes/sha256';
 import { hexToUint8Array } from '@veil/utils';
+import {
+  Sep30Client,
+  collectRecoverySignatures,
+  type Sep30Identity,
+  type Sep30Account,
+  type RecoveryServer,
+  type CollectedSignature,
+} from '@veil/recovery';
 
 export function generateMnemonicPhrase(): string {
   return bip39.generateMnemonic(wordlist);
@@ -282,5 +290,106 @@ export function initRecoveryInterceptor() {
   };
   (patchedGet as any).__patched = true;
   navigator.credentials.get = patchedGet;
+}
+
+// ── SEP-30 server-assisted recovery ─────────────────────────────────────────────
+//
+// The mnemonic-backup path above is fully self-custodial. SEP-30 complements it
+// with *server-assisted* recovery: the user registers identities with one or
+// more recovery servers, and after device loss those servers co-sign a
+// transaction that installs a fresh signer — no single party holds the key.
+//
+// The transport-level SEP-30 client lives in the SDK (`@veil/recovery`); the
+// helpers below wire it to the wallet's storage and the configured servers.
+
+export interface RecoveryServerConfig {
+  /** Base URL of the recovery server. */
+  baseUrl: string;
+  /** Optional SEP-10 JWT (or use getAuthToken for rotating tokens). */
+  authToken?: string;
+  /** Lazily resolve the current SEP-10 JWT before each request. */
+  getAuthToken?: () => string | null | undefined | Promise<string | null | undefined>;
+}
+
+const RECOVERY_SERVERS_KEY = 'invisible_wallet_recovery_servers';
+
+/** Build a SEP-30 client for each configured recovery server. */
+export function buildRecoveryClients(configs: RecoveryServerConfig[]): Sep30Client[] {
+  return configs.map((c) => new Sep30Client(c));
+}
+
+/**
+ * Persist the list of recovery-server base URLs so they can be rediscovered
+ * after device loss (the URLs are not secret; tokens are never stored here).
+ */
+export function rememberRecoveryServers(configs: RecoveryServerConfig[]): void {
+  if (typeof localStorage === 'undefined') return;
+  localStorage.setItem(RECOVERY_SERVERS_KEY, JSON.stringify(configs.map((c) => c.baseUrl)));
+}
+
+/** Read back the previously remembered recovery-server base URLs. */
+export function getRememberedRecoveryServers(): string[] {
+  if (typeof localStorage === 'undefined') return [];
+  const raw = localStorage.getItem(RECOVERY_SERVERS_KEY);
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Register the wallet account with every configured recovery server and persist
+ * the server URLs for later recovery. Returns each server's account view
+ * (including the signer it contributes, which must then be added on-chain).
+ */
+export async function registerWithRecoveryServers(
+  address: string,
+  identities: Sep30Identity[],
+  configs: RecoveryServerConfig[],
+): Promise<Sep30Account[]> {
+  const clients = buildRecoveryClients(configs);
+  const accounts = await Promise.all(clients.map((c) => c.registerAccount(address, identities)));
+  rememberRecoveryServers(configs);
+  return accounts;
+}
+
+/**
+ * Resolve each configured server into a {@link RecoveryServer} (client + the
+ * server's signer key on the account), ready for {@link recoverSignatures}.
+ * Servers that don't have the account registered are skipped.
+ */
+export async function resolveRecoveryServers(
+  address: string,
+  configs: RecoveryServerConfig[],
+): Promise<RecoveryServer[]> {
+  const clients = buildRecoveryClients(configs);
+  const resolved = await Promise.all(
+    clients.map(async (client): Promise<RecoveryServer | null> => {
+      try {
+        const account = await client.getAccount(address);
+        const signerKey = account.signers[0]?.key;
+        return signerKey ? { client, signerKey } : null;
+      } catch {
+        return null;
+      }
+    }),
+  );
+  return resolved.filter((r): r is RecoveryServer => r !== null);
+}
+
+/**
+ * Collect recovery-server signatures for a transaction that re-establishes a
+ * signer after device loss. Pass `requireAll: false` for an M-of-N threshold.
+ */
+export async function recoverSignatures(
+  servers: RecoveryServer[],
+  address: string,
+  transactionXdr: string,
+  opts: { requireAll?: boolean } = {},
+): Promise<CollectedSignature[]> {
+  return collectRecoverySignatures(servers, address, transactionXdr, opts);
 }
 

--- a/frontend/wallet/tsconfig.json
+++ b/frontend/wallet/tsconfig.json
@@ -18,6 +18,7 @@
       "@/*": ["./*"],
       "@veil/sdk": ["../../sdk/src/useInvisibleWallet"],
       "@veil/utils": ["../../sdk/src/utils"],
+      "@veil/recovery": ["../../sdk/src/recovery/sep30"],
       "react": ["./node_modules/@types/react"],
       "react/jsx-runtime": ["./node_modules/@types/react/jsx-runtime"],
       "@stellar/stellar-sdk": ["./node_modules/@stellar/stellar-sdk"]

--- a/scripts/reproducible-build.sh
+++ b/scripts/reproducible-build.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+#
+# Reproducible WASM build & hash verification for the Veil contracts.
+#
+# Builds the Soroban contracts in a pinned, deterministic environment, computes
+# the SHA-256 of each release .wasm artifact, and either checks them against the
+# committed contracts/expected-hashes.json (default) or regenerates that file.
+#
+# Determinism strategy
+# --------------------
+# By default the build runs inside a pinned Docker image with the repository
+# mounted at a FIXED path (/work) and a fixed CARGO_HOME, so the absolute paths
+# rustc embeds are identical on every machine — including GitHub Actions. The
+# toolchain version is pinned by contracts/rust-toolchain.toml and dependencies
+# by contracts/Cargo.lock (built with --locked). A third party who runs this
+# script with the same image gets byte-identical wasm and therefore the same
+# hashes.
+#
+# Usage:
+#   scripts/reproducible-build.sh            # build + check against committed hashes
+#   scripts/reproducible-build.sh --update   # build + (re)write expected-hashes.json
+#   scripts/reproducible-build.sh --no-docker # use the host toolchain instead of Docker
+#
+# Exit status: 0 on success / match, non-zero on build failure or hash drift.
+
+set -euo pipefail
+
+# Pinned build image. Matches contracts/rust-toolchain.toml (channel 1.85.0).
+# Pin to a digest for the strongest guarantee; the tag is used here for clarity.
+BUILD_IMAGE="${VEIL_BUILD_IMAGE:-rust:1.85.0-bookworm}"
+TARGET="wasm32-unknown-unknown"
+
+MODE="check"
+USE_DOCKER=1
+for arg in "$@"; do
+  case "$arg" in
+    --update)    MODE="update" ;;
+    --check)     MODE="check" ;;
+    --no-docker) USE_DOCKER=0 ;;
+    *) echo "Unknown argument: $arg" >&2; exit 2 ;;
+  esac
+done
+
+# Resolve repo root (this script lives in scripts/).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+HASHES_FILE="$REPO_ROOT/contracts/expected-hashes.json"
+
+echo "==> Building contracts ($TARGET, release)"
+
+build_in_docker() {
+  # Mount at a fixed path so embedded source paths are stable across machines.
+  docker run --rm \
+    -v "$REPO_ROOT":/work \
+    -w /work/contracts \
+    -e CARGO_HOME=/usr/local/cargo \
+    "$BUILD_IMAGE" \
+    bash -euo pipefail -c '
+      rustup target add '"$TARGET"' >/dev/null 2>&1 || true
+      cargo build --release --locked --target '"$TARGET"'
+    '
+}
+
+build_on_host() {
+  ( cd "$REPO_ROOT/contracts"
+    rustup target add "$TARGET" >/dev/null 2>&1 || true
+    cargo build --release --locked --target "$TARGET" )
+}
+
+if [ "$USE_DOCKER" -eq 1 ]; then
+  echo "    using pinned image: $BUILD_IMAGE"
+  build_in_docker
+else
+  echo "    using host toolchain (ensure it matches contracts/rust-toolchain.toml)"
+  build_on_host
+fi
+
+WASM_DIR="$REPO_ROOT/contracts/target/$TARGET/release"
+echo "==> Hashing artifacts in $WASM_DIR"
+
+# Build a JSON object { "<file>.wasm": "<sha256>", ... } sorted by filename.
+COMPUTED="$(
+  cd "$WASM_DIR"
+  shopt -s nullglob
+  files=( *.wasm )
+  if [ ${#files[@]} -eq 0 ]; then
+    echo "No .wasm artifacts produced — build may have failed." >&2
+    exit 1
+  fi
+  for f in "${files[@]}"; do
+    printf '%s  %s\n' "$(sha256sum "$f" | cut -d' ' -f1)" "$f"
+  done | sort -k2 | python3 -c '
+import sys, json
+out = {}
+for line in sys.stdin:
+    digest, name = line.split()
+    out[name] = digest
+print(json.dumps(out, indent=2, sort_keys=True))
+'
+)"
+
+echo "$COMPUTED"
+
+if [ "$MODE" = "update" ]; then
+  python3 - "$HASHES_FILE" <<PY
+import json, sys
+artifacts = json.loads('''$COMPUTED''')
+doc = {
+    "_comment": "SHA-256 of release wasm artifacts. Regenerate with scripts/reproducible-build.sh --update.",
+    "toolchain": "1.85.0",
+    "image": "$BUILD_IMAGE",
+    "target": "$TARGET",
+    "artifacts": artifacts,
+}
+with open(sys.argv[1], "w") as fh:
+    fh.write(json.dumps(doc, indent=2, sort_keys=True) + "\n")
+print("==> Wrote", sys.argv[1])
+PY
+  exit 0
+fi
+
+# --- check mode ---
+if [ ! -f "$HASHES_FILE" ]; then
+  echo "ERROR: $HASHES_FILE not found. Seed it with: scripts/reproducible-build.sh --update" >&2
+  exit 1
+fi
+
+python3 - "$HASHES_FILE" <<PY
+import json, sys
+computed = json.loads('''$COMPUTED''')
+with open(sys.argv[1]) as fh:
+    expected = json.load(fh).get("artifacts", {})
+
+if not expected:
+    print("ERROR: expected-hashes.json has no artifacts; seed it with --update", file=sys.stderr)
+    sys.exit(1)
+
+ok = True
+for name in sorted(set(expected) | set(computed)):
+    exp = expected.get(name)
+    got = computed.get(name)
+    if exp == got:
+        print(f"  OK   {name}  {got}")
+    else:
+        ok = False
+        print(f"  DRIFT {name}\n        expected {exp}\n        got      {got}", file=sys.stderr)
+
+if not ok:
+    print("\nHash drift detected. If this change is intentional, regenerate with\n  scripts/reproducible-build.sh --update\nand commit contracts/expected-hashes.json.", file=sys.stderr)
+    sys.exit(1)
+print("\n==> All wasm hashes match the committed expected-hashes.json")
+PY

--- a/sdk/package-lock.json
+++ b/sdk/package-lock.json
@@ -13,6 +13,9 @@
       },
       "devDependencies": {
         "@size-limit/preset-small-lib": "^12.1.0",
+        "@stryker-mutator/core": "^8.7.0",
+        "@stryker-mutator/jest-runner": "^8.7.0",
+        "@stryker-mutator/typescript-checker": "^8.7.0",
         "@testing-library/react": "^16.0.0",
         "@types/jest": "^29.0.0",
         "@types/node": "^20.0.0",
@@ -45,14 +48,28 @@
         }
       }
     },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -76,6 +93,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -102,17 +120,30 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-annotate-as-pure": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.29.7.tgz",
+      "integrity": "sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -135,46 +166,95 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+    "node_modules/@babel/helper-create-class-features-plugin": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.29.7.tgz",
+      "integrity": "sha512-IY3ZD9Tmooqr3TUhc3DUWxiuo8xx1DWLhd5M7hQ+ZWJamqM2BbalrBJb2MisSLoYorOj75U03qULCxQTY9r3hg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-annotate-as-pure": "^7.29.7",
+        "@babel/helper-member-expression-to-functions": "^7.29.7",
+        "@babel/helper-optimise-call-expression": "^7.29.7",
+        "@babel/helper-replace-supers": "^7.29.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "semver": "^6.3.1"
       },
       "engines": {
         "node": ">=6.9.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.29.7.tgz",
+      "integrity": "sha512-j+7JYmk1JYDtACIGj0QJqqWZjoUpMoEikQGADMaHgCMCSDqd2+P32rfcibUNrGOMWrlzK1WJBdxrB3JJQZwWtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-optimise-call-expression": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.29.7.tgz",
+      "integrity": "sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
@@ -187,10 +267,42 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-replace-supers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.29.7.tgz",
+      "integrity": "sha512-atfGXWSeCiF4DnKZIfmJfQRkSw9b9gNNXR1kqKjbhG4pGYCOnkp8OcTB8E3NXjBu8NpheSnOeNKz8KT7UNFTmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-member-expression-to-functions": "^7.29.7",
+        "@babel/helper-optimise-call-expression": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.29.7.tgz",
+      "integrity": "sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -198,9 +310,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -232,19 +344,55 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-proposal-decorators": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.24.7.tgz",
+      "integrity": "sha512-RL9GR0pUG5Kc8BUWLNDm2T5OpYwSX15r98I0IkgmRQTXuELq/OynH8xtMTMvTJFjXbMWFVTKtYkTaYQsuAwQlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.24.7",
+        "@babel/helper-plugin-utils": "^7.24.7",
+        "@babel/plugin-syntax-decorators": "^7.24.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-proposal-explicit-resource-management": {
+      "version": "7.27.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-explicit-resource-management/-/plugin-proposal-explicit-resource-management-7.27.4.tgz",
+      "integrity": "sha512-1SwtCDdZWQvUU1i7wt/ihP7W38WjC3CSTOHAl+Xnbze8+bbMNjRvRQydnj0k9J1jPqCAZctBFp6NHJXkrVVmEA==",
+      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-explicit-resource-management instead.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/plugin-transform-destructuring": "^7.27.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-async-generators": {
@@ -294,6 +442,22 @@
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-decorators": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.29.7.tgz",
+      "integrity": "sha512-9MTTLbF39X6sqM92JPEsoI7++26hjZvzkxKZy64aMhWLH2mPkJ/Q3AV4QLmls3R14FpSpkOwQQfUh962JGQxxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -486,6 +650,80 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-transform-destructuring": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.29.7.tgz",
+      "integrity": "sha512-iPX8aD6H9zV5s7ZsqTdNocPN/MGQ5sSMnElKrktxjJRMnB2jN/1p2+R7GkfD6CAYoVFqy5A4XnSIUeGgJzIWpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-commonjs": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.29.7.tgz",
+      "integrity": "sha512-j0vCldybPC5b5dwCQOJ21uKtHzt7hxLygJTg9eF1ScfaikEDNfzn94XoW5Fi+seBR0nCyL23xaBFFkq7dTM8XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-typescript": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.29.7.tgz",
+      "integrity": "sha512-jK52h8LaLc7JarhQV2ofeFMts4H7vnOXnqZNA6fYglBTZewRBE51KWt3BUltW1P+KoPsYkHoJeXePuz4zo2LMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.29.7",
+        "@babel/helper-create-class-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7",
+        "@babel/plugin-syntax-typescript": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-typescript": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.24.7.tgz",
+      "integrity": "sha512-SyXRe3OdWwIwalxDg5UtJnJQO+YPcTfwiIY2B0Xlddh9o7jpWLvv8X1RthIeDOxQ+O1ML5BLPCONToObyVQVuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.24.7",
+        "@babel/helper-validator-option": "^7.24.7",
+        "@babel/plugin-syntax-jsx": "^7.24.7",
+        "@babel/plugin-transform-modules-commonjs": "^7.24.7",
+        "@babel/plugin-transform-typescript": "^7.24.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/runtime": {
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
@@ -497,33 +735,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -531,14 +769,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -989,6 +1227,265 @@
       "os": [
         "win32"
       ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/checkbox": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-3.0.1.tgz",
+      "integrity": "sha512-0hm2nrToWUdD6/UHnel/UKGdk1//ke5zGUpHIvk5ZWmaKezlGxZkOJXNSWsdxO/rEqTkbB3lNC2J6nBElV2aAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/figures": "^1.0.6",
+        "@inquirer/type": "^2.0.0",
+        "ansi-escapes": "^4.3.2",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-4.0.1.tgz",
+      "integrity": "sha512-46yL28o2NJ9doViqOy0VDcoTzng7rAb6yPQKU7VDLqkmbCaH4JqK4yk4XqlzNWy9PVC5pG1ZUXPBQv+VqnYs2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/type": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-9.2.1.tgz",
+      "integrity": "sha512-F2VBt7W/mwqEU4bL0RnHNZmC/OxzNx9cOYxHqnXX3MP6ruYvZUZAW9imgN9+h/uBT/oP8Gh888J2OZSbjSeWcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/figures": "^1.0.6",
+        "@inquirer/type": "^2.0.0",
+        "@types/mute-stream": "^0.0.4",
+        "@types/node": "^22.5.5",
+        "@types/wrap-ansi": "^3.0.0",
+        "ansi-escapes": "^4.3.2",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^1.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/@types/node": {
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/editor": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-3.0.1.tgz",
+      "integrity": "sha512-VA96GPFaSOVudjKFraokEEmUQg/Lub6OXvbIEZU1SDCmBzRkHGhxoFAVaF30nyiB4m5cEbDgiI2QRacXZ2hw9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/type": "^2.0.0",
+        "external-editor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/expand": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-3.0.1.tgz",
+      "integrity": "sha512-ToG8d6RIbnVpbdPdiN7BCxZGiHOTomOX94C2FaT5KOHupV40tKEDozp12res6cMIfRKrXLJyexAZhWVHgbALSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/type": "^2.0.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
+      "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/input": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-3.0.1.tgz",
+      "integrity": "sha512-BDuPBmpvi8eMCxqC5iacloWqv+5tQSJlUafYWUe31ow1BVXjW2a5qe3dh4X/Z25Wp22RwvcaLCc2siHobEOfzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/type": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/number": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-2.0.1.tgz",
+      "integrity": "sha512-QpR8jPhRjSmlr/mD2cw3IR8HRO7lSVOnqUvQa8scv1Lsr3xoAMMworcYW3J13z3ppjBFBD2ef1Ci6AE5Qn8goQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/type": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/password": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-3.0.1.tgz",
+      "integrity": "sha512-haoeEPUisD1NeE2IanLOiFr4wcTXGWrBOyAyPZi1FfLJuXOzNmxCJPgUrGYKVh+Y8hfGJenIfz5Wb/DkE9KkMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/type": "^2.0.0",
+        "ansi-escapes": "^4.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/prompts": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-6.0.1.tgz",
+      "integrity": "sha512-yl43JD/86CIj3Mz5mvvLJqAOfIup7ncxfJ0Btnl0/v5TouVUyeEdcpknfgc+yMevS/48oH9WAkkw93m7otLb/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/checkbox": "^3.0.1",
+        "@inquirer/confirm": "^4.0.1",
+        "@inquirer/editor": "^3.0.1",
+        "@inquirer/expand": "^3.0.1",
+        "@inquirer/input": "^3.0.1",
+        "@inquirer/number": "^2.0.1",
+        "@inquirer/password": "^3.0.1",
+        "@inquirer/rawlist": "^3.0.1",
+        "@inquirer/search": "^2.0.1",
+        "@inquirer/select": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/rawlist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-3.0.1.tgz",
+      "integrity": "sha512-VgRtFIwZInUzTiPLSfDXK5jLrnpkuSOh1ctfaoygKAdPqjcjKYmGh6sCY1pb0aGnCGsmhUxoqLDUAU0ud+lGXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/type": "^2.0.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/search": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-2.0.1.tgz",
+      "integrity": "sha512-r5hBKZk3g5MkIzLVoSgE4evypGqtOannnB3PKTG9NRZxyFRKcfzrdxXXPcoJQsxJPzvdSU2Rn7pB7lw0GCmGAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/figures": "^1.0.6",
+        "@inquirer/type": "^2.0.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-3.0.1.tgz",
+      "integrity": "sha512-lUDGUxPhdWMkN/fHy1Lk7pF3nK1fh/gqeyWXmctefhxLYxlDsc7vsPBEpxrfVGDsVdyYJsiJoD4bJ1b623cV1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/figures": "^1.0.6",
+        "@inquirer/type": "^2.0.0",
+        "ansi-escapes": "^4.3.2",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-2.0.0.tgz",
+      "integrity": "sha512-XvJRx+2KR3YXyYtPUUy+qd9i7p+GO9Ko6VIIpWlBrpWwXDv8WLFeHTxz35CfQFUiBMLXlGHhGzys7lqit9gWag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mute-stream": "^1.0.0"
+      },
       "engines": {
         "node": ">=18"
       }
@@ -1716,12 +2213,32 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.10",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
       "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
@@ -1834,13 +2351,451 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@stryker-mutator/api": {
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/api/-/api-8.7.1.tgz",
+      "integrity": "sha512-56vxcVxIfW0jxJhr7HB9Zx6Xr5/M95RG9MUK1DtbQhlmQesjpfBBsrPLOPzBJaITPH/vOYykuJ69vgSAMccQyw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mutation-testing-metrics": "3.3.0",
+        "mutation-testing-report-schema": "3.3.0",
+        "tslib": "~2.7.0",
+        "typed-inject": "~4.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/core": {
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/core/-/core-8.7.1.tgz",
+      "integrity": "sha512-r2AwhHWkHq6yEe5U8mAzPSWewULbv9YMabLHRzLjZnjj+Ipxtg+Zo22rrUc2Zl7mnYvb9w34bdlEzGz6MKgX2g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@inquirer/prompts": "^6.0.0",
+        "@stryker-mutator/api": "8.7.1",
+        "@stryker-mutator/instrumenter": "8.7.1",
+        "@stryker-mutator/util": "8.7.1",
+        "ajv": "~8.17.1",
+        "chalk": "~5.3.0",
+        "commander": "~12.1.0",
+        "diff-match-patch": "1.0.5",
+        "emoji-regex": "~10.4.0",
+        "execa": "~9.4.0",
+        "file-url": "~4.0.0",
+        "lodash.groupby": "~4.6.0",
+        "minimatch": "~9.0.5",
+        "mutation-testing-elements": "3.4.0",
+        "mutation-testing-metrics": "3.3.0",
+        "mutation-testing-report-schema": "3.3.0",
+        "npm-run-path": "~6.0.0",
+        "progress": "~2.0.3",
+        "rxjs": "~7.8.1",
+        "semver": "^7.6.3",
+        "source-map": "~0.7.4",
+        "tree-kill": "~1.2.2",
+        "tslib": "2.7.0",
+        "typed-inject": "~4.0.0",
+        "typed-rest-client": "~2.1.0"
+      },
+      "bin": {
+        "stryker": "bin/stryker.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/chalk": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/emoji-regex": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
+      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@stryker-mutator/core/node_modules/execa": {
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.4.1.tgz",
+      "integrity": "sha512-5eo/BRqZm3GYce+1jqX/tJ7duA2AnE39i88fuedNFUV8XxGxUpF3aWkBRfbUcjV49gCkvS/pzc0YrCPhaIewdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.3",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.0",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/human-signals": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter": {
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/instrumenter/-/instrumenter-8.7.1.tgz",
+      "integrity": "sha512-HSq4VHXesQCMR3hr6bn41DAeJ0yuP2vp9KSnls2TySNawFVWOCaKXpBX29Skj3zJQh7dnm7HuQg8HuXvJK15oA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/core": "~7.25.2",
+        "@babel/generator": "~7.25.0",
+        "@babel/parser": "~7.25.0",
+        "@babel/plugin-proposal-decorators": "~7.24.7",
+        "@babel/plugin-proposal-explicit-resource-management": "^7.24.7",
+        "@babel/preset-typescript": "~7.24.7",
+        "@stryker-mutator/api": "8.7.1",
+        "@stryker-mutator/util": "8.7.1",
+        "angular-html-parser": "~6.0.2",
+        "semver": "~7.6.3",
+        "weapon-regex": "~1.3.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/core": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.9.tgz",
+      "integrity": "sha512-WYvQviPw+Qyib0v92AwNIrdLISTp7RfDkM7bPqBvpbnhY4wq8HvHBZREVdYDXk98C8BkOIVnHAY3yvj7AVISxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.2.0",
+        "@babel/code-frame": "^7.25.9",
+        "@babel/generator": "^7.25.9",
+        "@babel/helper-compilation-targets": "^7.25.9",
+        "@babel/helper-module-transforms": "^7.25.9",
+        "@babel/helpers": "^7.25.9",
+        "@babel/parser": "^7.25.9",
+        "@babel/template": "^7.25.9",
+        "@babel/traverse": "^7.25.9",
+        "@babel/types": "^7.25.9",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/generator": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.9.tgz",
+      "integrity": "sha512-omlUGkr5EaoIJrhLf9CJ0TvjBRpd9+AXRG//0GEQ9THSo8wPiTlbpy1/Ow8ZTrbXpjd9FHXfbFQx32I04ht0FA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.25.9",
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/parser": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.9.tgz",
+      "integrity": "sha512-aI3jjAAO1fh7vY/pBGsn1i9LDbRP43+asrRlkPuTXW5yHXtd1NgTEMudbBoDDxrf1daEEfPJqR+JBMakzrR4Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.25.9"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@stryker-mutator/jest-runner": {
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/jest-runner/-/jest-runner-8.7.1.tgz",
+      "integrity": "sha512-507jgu9E0yNDwMN56p4J+iFI77+rPDLDV91qYGbBI6fvy5c7rBQ63l64FtAFMTG75f4gCZ6C/Pq3nXTQx6PMjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@stryker-mutator/api": "8.7.1",
+        "@stryker-mutator/util": "8.7.1",
+        "semver": "~7.6.3",
+        "tslib": "~2.7.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@stryker-mutator/core": "~8.7.0"
+      }
+    },
+    "node_modules/@stryker-mutator/jest-runner/node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@stryker-mutator/typescript-checker": {
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/typescript-checker/-/typescript-checker-8.7.1.tgz",
+      "integrity": "sha512-ZliTju52pOR9Xnh1AjGn4Oet7lTWjbDbi6RfoBGAPzVSZSYcZNnupr3tBtDJX4p2qVYYfYvmhoAKYXbe30dWBQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@stryker-mutator/api": "8.7.1",
+        "@stryker-mutator/util": "8.7.1",
+        "semver": "~7.6.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@stryker-mutator/core": "~8.7.0",
+        "typescript": ">=3.6"
+      }
+    },
+    "node_modules/@stryker-mutator/typescript-checker/node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@stryker-mutator/util": {
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/util/-/util-8.7.1.tgz",
+      "integrity": "sha512-Oj/sIHZI1GLfGOHKnud4Gw0ZRufm7ONoQYNnhcaAYEXTWraYVcV7mue/th8fZComTHvDPA8Ge8U16FvWYEb8dg==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -1861,7 +2816,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -1875,7 +2829,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -1890,8 +2843,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@testing-library/react": {
       "version": "16.3.2",
@@ -1936,8 +2888,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2044,6 +2995,16 @@
         "parse5": "^7.0.0"
       }
     },
+    "node_modules/@types/mute-stream": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mute-stream/-/mute-stream-0.0.4.tgz",
+      "integrity": "sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "20.19.33",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.33.tgz",
@@ -2067,6 +3028,7 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -2078,6 +3040,7 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -2093,6 +3056,13 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/wrap-ansi": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz",
+      "integrity": "sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==",
       "dev": true,
       "license": "MIT"
     },
@@ -2171,6 +3141,36 @@
         "node": ">= 6.0.0"
       }
     },
+    "node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/angular-html-parser": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/angular-html-parser/-/angular-html-parser-6.0.2.tgz",
+      "integrity": "sha512-8+sH1TwYxv8XsQes1psxTHMtWRBbJFA/jY0ThqpT4AgCiRdhTtRxru0vlBfyRJpL9CHd3G06k871bR2vyqaM6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -2243,7 +3243,6 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -2409,6 +3408,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2602,6 +3602,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ci-info": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
@@ -2624,6 +3631,16 @@
       "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/cliui": {
       "version": "8.0.1",
@@ -2881,9 +3898,19 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/des.js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
+      "integrity": "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "node_modules/detect-newline": {
@@ -2895,6 +3922,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/diff-match-patch": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
+      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
@@ -2911,8 +3945,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/domexception": {
       "version": "4.0.0",
@@ -3214,6 +4247,34 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/external-editor/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/fast-check": {
       "version": "4.8.0",
       "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.8.0.tgz",
@@ -3254,12 +4315,36 @@
       ],
       "license": "MIT"
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
@@ -3278,6 +4363,35 @@
       "license": "MIT",
       "dependencies": {
         "is-retry-allowed": "^3.0.0"
+      }
+    },
+    "node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/file-url": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/file-url/-/file-url-4.0.0.tgz",
+      "integrity": "sha512-vRCdScQ6j3Ku6Kd7W1kZk9c++5SqD6Xz5Jotrjr/nkY714M14RFHy/AAVA2WQvpsqVAVgTbDrYyBpU205F0cLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/fill-range": {
@@ -3798,6 +4912,19 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
@@ -3843,6 +4970,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/isarray": {
@@ -3948,6 +5088,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -5213,6 +6354,13 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/js-md4": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/js-md4/-/js-md4-0.3.2.tgz",
+      "integrity": "sha512-/GDnfQYsltsjRswQhN9fhv3EMw2sCpUdrdxyWDOUK7eyD++r3gRhzgiQgc/x4MAv2i1iuQ4lxO5mvqM3vj4bwA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5300,6 +6448,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -5366,6 +6521,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/lodash.groupby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
+      "integrity": "sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -5402,7 +6564,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -5514,6 +6675,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -5543,6 +6711,40 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/mutation-testing-elements": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/mutation-testing-elements/-/mutation-testing-elements-3.4.0.tgz",
+      "integrity": "sha512-zFJtGlobq+Fyq95JoJj0iqrmwLSLQyIJuDATLwFMDSJCxpGN8kHCA6S4LoLJnkSL6bg4Aqultp8OBSMxGbW3EA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/mutation-testing-metrics": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/mutation-testing-metrics/-/mutation-testing-metrics-3.3.0.tgz",
+      "integrity": "sha512-vZEJ84SpK3Rwyk7k28SORS5o6ZDtehwifLPH6fQULrozJqlz2Nj8vi52+CjA+aMZCyyKB+9eYUh1HtiWVo4o/A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mutation-testing-report-schema": "3.3.0"
+      }
+    },
+    "node_modules/mutation-testing-report-schema": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/mutation-testing-report-schema/-/mutation-testing-report-schema-3.3.0.tgz",
+      "integrity": "sha512-DF56q0sb0GYzxYUYNdzlfQzyE5oJBEasz8zL76bt3OFJU8q4iHSdUDdihPWWJD+4JLxSs3neM/R968zYdy0SWQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/mute-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
+      "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
     },
     "node_modules/nanoid": {
       "version": "5.1.11",
@@ -5631,6 +6833,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -5655,6 +6870,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/p-limit": {
@@ -5726,6 +6951,19 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -5861,6 +7099,32 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/pretty-ms": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -5921,6 +7185,22 @@
       ],
       "license": "MIT"
     },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
@@ -5943,6 +7223,7 @@
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5956,6 +7237,7 @@
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -5975,6 +7257,16 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6041,6 +7333,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/safe-buffer": {
@@ -6163,6 +7465,82 @@
         "node": ">=8"
       }
     },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -6183,6 +7561,7 @@
       "integrity": "sha512-VnDS2fycANrJFVPQwjaD+h+hkISY7EB3LsPsYWje4lBCjQwwsZLxjwwRwVJKHrcj2ZqyG+DdXykWm9mbZklZrw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bytes-iec": "^3.1.1",
         "lilconfig": "^3.1.3",
@@ -6420,11 +7799,25 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "os-tmpdir": "~1.0.2"
+      },
+      "engines": {
+        "node": ">=0.6.0"
       }
     },
     "node_modules/tmpl": {
@@ -6494,6 +7887,16 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
       }
     },
     "node_modules/ts-jest": {
@@ -6575,6 +7978,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
     "node_modules/type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -6612,12 +8032,40 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/typed-inject": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/typed-inject/-/typed-inject-4.0.0.tgz",
+      "integrity": "sha512-OuBL3G8CJlS/kjbGV/cN8Ni32+ktyyi6ADDZpKvksbX0fYBV5WcukhRCYa7WqLce7dY/Br2dwtmJ9diiadLFpg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/typed-rest-client": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-2.1.0.tgz",
+      "integrity": "sha512-Nel9aPbgSzRxfs1+4GoSB4wexCF+4Axlk7OSGVQCMa+4fWcyxIsN/YNmkp0xTT2iQzMD98h8yFLav/cNaULmRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "des.js": "^1.1.0",
+        "js-md4": "^0.3.2",
+        "qs": "^6.10.3",
+        "tunnel": "0.0.6",
+        "underscore": "^1.12.1"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6640,12 +8088,32 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/underscore": {
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/universalify": {
       "version": "0.2.0",
@@ -6742,6 +8210,13 @@
       "dependencies": {
         "makeerror": "1.0.12"
       }
+    },
+    "node_modules/weapon-regex": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/weapon-regex/-/weapon-regex-1.3.6.tgz",
+      "integrity": "sha512-wsf1m1jmMrso5nhwVFJJHSubEBf3+pereGd7+nBKtYJ18KoB/PWJOHS3WRkwS04VrOU0iJr2bZU+l1QaTJ+9nA==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
@@ -6953,6 +8428,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors-cjs": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
+      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/sdk/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/sdk/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -2,11 +2,17 @@
 
 exports[`SDK API Surface should match the snapshot for main SDK exports 1`] = `
 [
+  "AttestationError: function(arity: 1)",
+  "AttestationPolicyError: function(arity: 1)",
   "NoGuardianSet: function(arity: 0)",
   "RecoveryNotPending: function(arity: 0)",
   "RecoveryTimelockActive: function(arity: 1)",
+  "Sep30Client: function(arity: 1)",
+  "Sep30Error: function(arity: 2)",
+  "TransactionOutbox: function(arity: 2)",
   "base64UrlEncode: function(arity: 1)",
   "bufferToHex: function(arity: 1)",
+  "collectRecoverySignatures: function(arity: 3)",
   "computeWalletAddress: function(arity: 2)",
   "computeWebAuthnMessageHash: function(arity: 2)",
   "derToRawSignature: function(arity: 1)",
@@ -17,6 +23,7 @@ exports[`SDK API Surface should match the snapshot for main SDK exports 1`] = `
   "parseClientDataJSON: function(arity: 1)",
   "sha256: function(arity: 1)",
   "useInvisibleWallet: function(arity: 1)",
+  "verifyAttestation: function(arity: 1)",
 ]
 `;
 

--- a/sdk/src/__tests__/attestation.test.ts
+++ b/sdk/src/__tests__/attestation.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Tests for WebAuthn attestation verification.
+ *
+ * A real `packed` self-attestation fixture is constructed in-test using Node's
+ * WebCrypto: we generate a P-256 key pair, build authData embedding the COSE
+ * public key, sign (authData ‖ clientDataHash), and assemble the CBOR
+ * attestationObject. No external dependencies or network access required.
+ */
+
+import { webcrypto } from 'node:crypto'
+import {
+  verifyAttestation,
+  AttestationError,
+  AttestationPolicyError,
+  type AttestationInfo,
+} from '../webauthn/attestation'
+
+// The attestation module uses the global `crypto.subtle`; provide Node's.
+beforeAll(() => {
+  Object.defineProperty(globalThis, 'crypto', { value: webcrypto, writable: true, configurable: true })
+})
+
+const subtle = webcrypto.subtle
+
+// ── Tiny CBOR encoder (just enough to build the fixture) ────────────────────────
+
+type CborMap = Array<[number | string, unknown]>
+
+function encodeHead(major: number, n: number): Uint8Array {
+  if (n < 24) return new Uint8Array([(major << 5) | n])
+  if (n < 0x100) return new Uint8Array([(major << 5) | 24, n])
+  if (n < 0x10000) return new Uint8Array([(major << 5) | 25, n >> 8, n & 0xff])
+  return new Uint8Array([(major << 5) | 26, (n >>> 24) & 0xff, (n >> 16) & 0xff, (n >> 8) & 0xff, n & 0xff])
+}
+
+function concat(...parts: Uint8Array[]): Uint8Array {
+  const total = parts.reduce((s, p) => s + p.length, 0)
+  const out = new Uint8Array(total)
+  let off = 0
+  for (const p of parts) { out.set(p, off); off += p.length }
+  return out
+}
+
+function cbor(value: unknown): Uint8Array {
+  if (typeof value === 'number') {
+    return value >= 0 ? encodeHead(0, value) : encodeHead(1, -1 - value)
+  }
+  if (typeof value === 'string') {
+    const bytes = new TextEncoder().encode(value)
+    return concat(encodeHead(3, bytes.length), bytes)
+  }
+  if (value instanceof Uint8Array) {
+    return concat(encodeHead(2, value.length), value)
+  }
+  if (Array.isArray(value) && value.every(v => Array.isArray(v))) {
+    // map represented as [[k,v],...]
+    const entries = value as CborMap
+    const parts = [encodeHead(5, entries.length)]
+    for (const [k, v] of entries) { parts.push(cbor(k), cbor(v)) }
+    return concat(...parts)
+  }
+  if (Array.isArray(value)) {
+    const parts = [encodeHead(4, value.length)]
+    for (const v of value) parts.push(cbor(v))
+    return concat(...parts)
+  }
+  throw new Error('cbor: unsupported fixture value')
+}
+
+// ── raw (r‖s) → DER ─────────────────────────────────────────────────────────────
+
+function rawToDer(raw: Uint8Array): Uint8Array {
+  const r = raw.slice(0, 32)
+  const s = raw.slice(32, 64)
+  const fmt = (b: Uint8Array): Uint8Array => {
+    let i = 0
+    while (i < b.length - 1 && b[i] === 0) i++
+    let t: Uint8Array = b.slice(i)
+    if (t[0] & 0x80) t = concat(new Uint8Array([0]), t)
+    return t
+  }
+  const rd = fmt(r), sd = fmt(s)
+  const body = concat(new Uint8Array([0x02, rd.length]), rd, new Uint8Array([0x02, sd.length]), sd)
+  return concat(new Uint8Array([0x30, body.length]), body)
+}
+
+// ── Fixture builder ─────────────────────────────────────────────────────────────
+
+const AAGUID = new Uint8Array(16).fill(0xab)
+const CRED_ID = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8])
+const RP_ID_HASH = new Uint8Array(32).fill(0x11)
+
+async function buildPackedSelfAttestation(opts: { tamperSig?: boolean } = {}) {
+  const keyPair = await subtle.generateKey({ name: 'ECDSA', namedCurve: 'P-256' }, true, ['sign', 'verify'])
+  const rawPub = new Uint8Array(await subtle.exportKey('raw', keyPair.publicKey)) // 0x04‖x‖y
+  const x = rawPub.slice(1, 33)
+  const y = rawPub.slice(33, 65)
+
+  // COSE_Key for EC2 / P-256 / ES256
+  const cose = cbor([
+    [1, 2],     // kty: EC2
+    [3, -7],    // alg: ES256
+    [-1, 1],    // crv: P-256
+    [-2, x],
+    [-3, y],
+  ] as CborMap)
+
+  // authData: rpIdHash(32) | flags(1) | signCount(4) | aaguid(16) | credIdLen(2) | credId | cose
+  const header = new Uint8Array(37)
+  header.set(RP_ID_HASH, 0)
+  header[32] = 0x41 // UP | AT
+  new DataView(header.buffer).setUint32(33, 7, false) // signCount = 7
+  const credIdLen = new Uint8Array([0x00, CRED_ID.length])
+  const authData = concat(header, AAGUID, credIdLen, CRED_ID, cose)
+
+  const clientDataJSON = new TextEncoder().encode(JSON.stringify({ type: 'webauthn.create', challenge: 'abc', origin: 'https://veil.app' }))
+  const clientDataHash = new Uint8Array(await subtle.digest('SHA-256', clientDataJSON))
+
+  const signedData = concat(authData, clientDataHash)
+  const rawSig = new Uint8Array(await subtle.sign({ name: 'ECDSA', hash: 'SHA-256' }, keyPair.privateKey, signedData))
+  if (opts.tamperSig) rawSig[10] ^= 0xff
+  const derSig = rawToDer(rawSig)
+
+  const attestationObject = cbor([
+    ['fmt', 'packed'],
+    ['attStmt', [['alg', -7], ['sig', derSig]] as CborMap],
+    ['authData', authData],
+  ] as CborMap)
+
+  return { attestationObject, clientDataJSON, publicKey: rawPub }
+}
+
+function buildNoneAttestation(): { attestationObject: Uint8Array; clientDataJSON: Uint8Array } {
+  const header = new Uint8Array(37)
+  header.set(RP_ID_HASH, 0)
+  header[32] = 0x41
+  new DataView(header.buffer).setUint32(33, 0, false)
+  // include a minimal COSE key so the public key is parseable too
+  const cose = cbor([[1, 2], [3, -7], [-1, 1], [-2, new Uint8Array(32).fill(1)], [-3, new Uint8Array(32).fill(2)]] as CborMap)
+  const authData = concat(header, AAGUID, new Uint8Array([0x00, CRED_ID.length]), CRED_ID, cose)
+  const attestationObject = cbor([['fmt', 'none'], ['attStmt', [] as CborMap], ['authData', authData]] as CborMap)
+  return { attestationObject, clientDataJSON: new TextEncoder().encode('{}') }
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────────
+
+describe('verifyAttestation', () => {
+  it('parses and verifies a packed self-attestation signature', async () => {
+    const fx = await buildPackedSelfAttestation()
+    const info = await verifyAttestation({ attestationObject: fx.attestationObject, clientDataJSON: fx.clientDataJSON })
+
+    expect(info.fmt).toBe('packed')
+    expect(info.attestationType).toBe('self')
+    expect(info.verified).toBe(true)
+    expect(info.aaguid).toBe('ab'.repeat(16))
+    expect(Array.from(info.credentialId)).toEqual(Array.from(CRED_ID))
+    expect(info.signCount).toBe(7)
+    expect(info.publicKey && Array.from(info.publicKey)).toEqual(Array.from(fx.publicKey))
+  })
+
+  it('throws AttestationError when the signature is tampered (requireValidSignature default)', async () => {
+    const fx = await buildPackedSelfAttestation({ tamperSig: true })
+    await expect(
+      verifyAttestation({ attestationObject: fx.attestationObject, clientDataJSON: fx.clientDataJSON }),
+    ).rejects.toThrow(AttestationError)
+  })
+
+  it('records verified:false instead of throwing when requireValidSignature is false', async () => {
+    const fx = await buildPackedSelfAttestation({ tamperSig: true })
+    const info = await verifyAttestation({
+      attestationObject: fx.attestationObject,
+      clientDataJSON: fx.clientDataJSON,
+      requireValidSignature: false,
+    })
+    expect(info.verified).toBe(false)
+  })
+
+  it('handles the "none" format: parses AAGUID/key but reports unverified', async () => {
+    const fx = buildNoneAttestation()
+    const info = await verifyAttestation({ attestationObject: fx.attestationObject, clientDataJSON: fx.clientDataJSON })
+    expect(info.fmt).toBe('none')
+    expect(info.attestationType).toBe('none')
+    expect(info.verified).toBe(false)
+    expect(info.aaguid).toBe('ab'.repeat(16))
+    expect(info.publicKey).toBeDefined()
+  })
+
+  // ── policy hook ───────────────────────────────────────────────────────────────
+
+  it('accepts when the policy approves (by AAGUID)', async () => {
+    const fx = await buildPackedSelfAttestation()
+    const allowed = new Set(['ab'.repeat(16)])
+    const policy = (i: AttestationInfo) => i.verified && allowed.has(i.aaguid)
+    const info = await verifyAttestation({ attestationObject: fx.attestationObject, clientDataJSON: fx.clientDataJSON, policy })
+    expect(info.verified).toBe(true)
+  })
+
+  it('rejects with AttestationPolicyError when the policy returns false', async () => {
+    const fx = await buildPackedSelfAttestation()
+    const policy = (i: AttestationInfo) => i.aaguid === 'deadbeef' // never matches
+    await expect(
+      verifyAttestation({ attestationObject: fx.attestationObject, clientDataJSON: fx.clientDataJSON, policy }),
+    ).rejects.toThrow(AttestationPolicyError)
+  })
+
+  it('rejects by format via the policy (reject unattested "none")', async () => {
+    const fx = buildNoneAttestation()
+    const policy = (i: AttestationInfo) => i.fmt !== 'none'
+    await expect(
+      verifyAttestation({ attestationObject: fx.attestationObject, clientDataJSON: fx.clientDataJSON, policy }),
+    ).rejects.toThrow(AttestationPolicyError)
+  })
+
+  it('throws on a malformed attestationObject', async () => {
+    await expect(
+      verifyAttestation({ attestationObject: new Uint8Array([0x01, 0x02]), clientDataJSON: new Uint8Array() }),
+    ).rejects.toThrow(AttestationError)
+  })
+})

--- a/sdk/src/__tests__/outbox.test.ts
+++ b/sdk/src/__tests__/outbox.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Unit tests for the offline transaction outbox.
+ *
+ * The Stellar SDK is mocked so no real network calls are made; we only need
+ * rpc.Api.GetTransactionStatus and TransactionBuilder.fromXDR.
+ */
+
+import { TransactionOutbox, type OutboxEntry } from '../outbox'
+
+// ── @stellar/stellar-sdk mock ─────────────────────────────────────────────────
+
+jest.mock('@stellar/stellar-sdk', () => ({
+  rpc: {
+    Api: {
+      GetTransactionStatus: { SUCCESS: 'SUCCESS', NOT_FOUND: 'NOT_FOUND', FAILED: 'FAILED' },
+    },
+  },
+  TransactionBuilder: {
+    // The outbox only needs fromXDR to return a truthy "transaction" it can pass
+    // to server.sendTransaction (which is itself mocked per-test).
+    fromXDR: jest.fn((xdr: string) => ({ __tx: xdr })),
+  },
+}))
+
+// ── In-memory StorageAdapter ──────────────────────────────────────────────────
+
+function makeStore() {
+  const map = new Map<string, string>()
+  return {
+    getItem: (k: string) => (map.has(k) ? map.get(k)! : null),
+    setItem: (k: string, v: string) => { map.set(k, v) },
+    removeItem: (k: string) => { map.delete(k) },
+    _map: map,
+  }
+}
+
+const SUCCESS = { status: 'SUCCESS' }
+const NOT_FOUND = { status: 'NOT_FOUND' }
+const FAILED = { status: 'FAILED' }
+
+function entryInput(overrides: Partial<{ hash: string; sequence: string; xdr: string }> = {}) {
+  return {
+    hash: overrides.hash ?? 'hash-1',
+    sequence: overrides.sequence ?? '100',
+    xdr: overrides.xdr ?? 'AAAA-signed-envelope',
+    networkPassphrase: 'Test SDF Network ; September 2015',
+  }
+}
+
+describe('TransactionOutbox', () => {
+  // ── persistence ────────────────────────────────────────────────────────────
+
+  describe('persistence', () => {
+    it('persists a queued transaction across a "reload" (new instance, same store)', async () => {
+      const store = makeStore()
+      const outbox = new TransactionOutbox(store)
+      await outbox.enqueue(entryInput())
+
+      // Simulate reload: a brand-new outbox reading the same backing store.
+      const reloaded = new TransactionOutbox(store)
+      const pending = await reloaded.pending()
+      expect(pending).toHaveLength(1)
+      expect(pending[0].hash).toBe('hash-1')
+      expect(pending[0].status).toBe('pending')
+    })
+
+    it('deduplicates enqueue by hash (re-enqueue is a no-op)', async () => {
+      const store = makeStore()
+      const outbox = new TransactionOutbox(store)
+      const first = await outbox.enqueue(entryInput())
+      const second = await outbox.enqueue(entryInput({ xdr: 'DIFFERENT-but-same-hash' }))
+
+      expect(second.createdAt).toBe(first.createdAt)
+      expect(await outbox.list()).toHaveLength(1)
+    })
+
+    it('orders pending entries by sequence number ascending', async () => {
+      const store = makeStore()
+      const outbox = new TransactionOutbox(store)
+      await outbox.enqueue(entryInput({ hash: 'b', sequence: '200' }))
+      await outbox.enqueue(entryInput({ hash: 'a', sequence: '100' }))
+
+      const pending = await outbox.pending()
+      expect(pending.map(e => e.hash)).toEqual(['a', 'b'])
+    })
+
+    it('returns [] for a corrupt payload rather than throwing', async () => {
+      const store = makeStore()
+      store.setItem('invisible_wallet_outbox', '{not valid json')
+      const outbox = new TransactionOutbox(store)
+      expect(await outbox.list()).toEqual([])
+    })
+  })
+
+  // ── replay: dedup / at-most-once ─────────────────────────────────────────────
+
+  describe('replay()', () => {
+    it('skips a transaction already on-chain without resubmitting (at-most-once)', async () => {
+      const store = makeStore()
+      const outbox = new TransactionOutbox(store)
+      await outbox.enqueue(entryInput())
+
+      const server = {
+        getTransaction: jest.fn().mockResolvedValue(SUCCESS),
+        sendTransaction: jest.fn(),
+      } as any
+
+      const result = await outbox.replay(server)
+
+      expect(server.sendTransaction).not.toHaveBeenCalled()
+      expect(result.skippedDuplicate).toHaveLength(1)
+      expect(result.confirmed).toHaveLength(0)
+      // Removed from the queue.
+      expect(await outbox.pending()).toHaveLength(0)
+    })
+
+    it('submits a not-yet-seen transaction and confirms it', async () => {
+      const store = makeStore()
+      const outbox = new TransactionOutbox(store)
+      await outbox.enqueue(entryInput())
+
+      const server = {
+        // 1st call (dedup check) → NOT_FOUND, 2nd call (waitFor) → SUCCESS
+        getTransaction: jest.fn()
+          .mockResolvedValueOnce(NOT_FOUND)
+          .mockResolvedValueOnce(SUCCESS),
+        sendTransaction: jest.fn().mockResolvedValue({ status: 'PENDING', hash: 'hash-1' }),
+      } as any
+
+      const result = await outbox.replay(server)
+
+      expect(server.sendTransaction).toHaveBeenCalledTimes(1)
+      expect(result.confirmed).toHaveLength(1)
+      expect(result.confirmed[0].hash).toBe('hash-1')
+      expect(await outbox.pending()).toHaveLength(0)
+    })
+
+    it('drops a transaction the network reports as FAILED without resending', async () => {
+      const store = makeStore()
+      const outbox = new TransactionOutbox(store)
+      await outbox.enqueue(entryInput())
+
+      const server = {
+        getTransaction: jest.fn().mockResolvedValue(FAILED),
+        sendTransaction: jest.fn(),
+      } as any
+
+      const result = await outbox.replay(server)
+
+      expect(server.sendTransaction).not.toHaveBeenCalled()
+      expect(result.failed).toHaveLength(1)
+      expect(await outbox.pending()).toHaveLength(0)
+    })
+
+    it('records a send ERROR as failed and removes it from the queue', async () => {
+      const store = makeStore()
+      const outbox = new TransactionOutbox(store)
+      await outbox.enqueue(entryInput())
+
+      const server = {
+        getTransaction: jest.fn().mockResolvedValue(NOT_FOUND),
+        sendTransaction: jest.fn().mockResolvedValue({
+          status: 'ERROR',
+          errorResult: { toXDR: () => 'base64error' },
+        }),
+      } as any
+
+      const result = await outbox.replay(server)
+      expect(result.failed).toHaveLength(1)
+      expect(await outbox.pending()).toHaveLength(0)
+    })
+  })
+
+  // ── offline → online transition ──────────────────────────────────────────────
+
+  describe('offline → online transition', () => {
+    it('keeps the entry queued while offline, then confirms it on reconnect', async () => {
+      const store = makeStore()
+      const outbox = new TransactionOutbox(store)
+      await outbox.enqueue(entryInput())
+
+      // OFFLINE: status lookup throws (no connectivity).
+      const offlineServer = {
+        getTransaction: jest.fn().mockRejectedValue(new Error('Network request failed')),
+        sendTransaction: jest.fn(),
+      } as any
+
+      const offlineResult = await outbox.replay(offlineServer)
+      expect(offlineServer.sendTransaction).not.toHaveBeenCalled()
+      expect(offlineResult.stillPending).toHaveLength(1)
+      // Survives — still queued for a later pass.
+      expect(await outbox.pending()).toHaveLength(1)
+
+      // ONLINE: now reachable; submit + confirm.
+      const onlineServer = {
+        getTransaction: jest.fn()
+          .mockResolvedValueOnce(NOT_FOUND)
+          .mockResolvedValueOnce(SUCCESS),
+        sendTransaction: jest.fn().mockResolvedValue({ status: 'PENDING', hash: 'hash-1' }),
+      } as any
+
+      const onlineResult = await outbox.replay(onlineServer)
+      expect(onlineServer.sendTransaction).toHaveBeenCalledTimes(1)
+      expect(onlineResult.confirmed).toHaveLength(1)
+      expect(await outbox.pending()).toHaveLength(0)
+    })
+
+    it('increments the attempt counter when a send is left pending', async () => {
+      const store = makeStore()
+      const outbox = new TransactionOutbox(store)
+      await outbox.enqueue(entryInput())
+
+      const server = {
+        getTransaction: jest.fn().mockResolvedValue(NOT_FOUND),
+        sendTransaction: jest.fn().mockResolvedValue({ status: 'PENDING', hash: 'hash-1' }),
+      } as any
+
+      // waitForConfirmation:false → leaves it pending after sending once.
+      await outbox.replay(server, { waitForConfirmation: false })
+      const pending: OutboxEntry[] = await outbox.pending()
+      expect(pending).toHaveLength(1)
+      expect(pending[0].attempts).toBe(1)
+    })
+  })
+})

--- a/sdk/src/__tests__/sep30.test.ts
+++ b/sdk/src/__tests__/sep30.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Tests for the SEP-30 recoverysigner client.
+ *
+ * The recovery server is mocked at the `fetch` boundary, so these tests exercise
+ * the full request/response and auth behaviour without a live server.
+ */
+
+import {
+  Sep30Client,
+  Sep30Error,
+  collectRecoverySignatures,
+  type Sep30Identity,
+} from '../recovery/sep30'
+
+const BASE = 'https://recovery.example.com'
+const ADDR = 'GCEXAMPLEACCOUNTADDRESSXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+const SIGNER = 'GSERVERSIGNERKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+
+const IDENTITIES: Sep30Identity[] = [
+  { role: 'owner', auth_methods: [{ type: 'stellar_address', value: ADDR }] },
+]
+
+/** Build a fetch mock that returns a JSON body with the given status. */
+function jsonFetch(status: number, body: unknown) {
+  return jest.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => JSON.stringify(body),
+  } as Response)
+}
+
+describe('Sep30Client', () => {
+  it('registers an account and returns the server signer', async () => {
+    const fetchImpl = jsonFetch(200, {
+      address: ADDR,
+      identities: [{ role: 'owner', authenticated: false }],
+      signers: [{ key: SIGNER }],
+    })
+    const client = new Sep30Client({ baseUrl: BASE, fetchImpl })
+
+    const account = await client.registerAccount(ADDR, IDENTITIES)
+
+    expect(account.signers[0].key).toBe(SIGNER)
+    const [url, init] = fetchImpl.mock.calls[0]
+    expect(url).toBe(`${BASE}/accounts/${ADDR}`)
+    expect(init.method).toBe('POST')
+    expect(JSON.parse(init.body)).toEqual({ identities: IDENTITIES })
+  })
+
+  it('attaches a static bearer token', async () => {
+    const fetchImpl = jsonFetch(200, { address: ADDR, identities: [], signers: [] })
+    const client = new Sep30Client({ baseUrl: BASE, fetchImpl, authToken: 'jwt-123' })
+
+    await client.getAccount(ADDR)
+
+    const [, init] = fetchImpl.mock.calls[0]
+    expect(init.headers.Authorization).toBe('Bearer jwt-123')
+  })
+
+  it('resolves a dynamic token via getAuthToken before each request', async () => {
+    const fetchImpl = jsonFetch(200, { address: ADDR, identities: [], signers: [] })
+    const getAuthToken = jest.fn().mockResolvedValue('fresh-jwt')
+    const client = new Sep30Client({ baseUrl: BASE, fetchImpl, getAuthToken })
+
+    await client.getAccount(ADDR)
+
+    expect(getAuthToken).toHaveBeenCalledTimes(1)
+    const [, init] = fetchImpl.mock.calls[0]
+    expect(init.headers.Authorization).toBe('Bearer fresh-jwt')
+  })
+
+  it('requests a signature for a transaction (re-establish a signer)', async () => {
+    const fetchImpl = jsonFetch(200, {
+      signature: 'BASE64SIG==',
+      network_passphrase: 'Test SDF Network ; September 2015',
+    })
+    const client = new Sep30Client({ baseUrl: BASE, fetchImpl })
+
+    const sig = await client.signTransaction(ADDR, SIGNER, 'AAAAtx==')
+
+    expect(sig.signature).toBe('BASE64SIG==')
+    const [url, init] = fetchImpl.mock.calls[0]
+    expect(url).toBe(`${BASE}/accounts/${ADDR}/sign/${SIGNER}`)
+    expect(JSON.parse(init.body)).toEqual({ transaction: 'AAAAtx==' })
+  })
+
+  it('throws Sep30Error with the server message on a non-2xx response', async () => {
+    const fetchImpl = jsonFetch(401, { error: 'authentication required' })
+    const client = new Sep30Client({ baseUrl: BASE, fetchImpl })
+
+    await expect(client.getAccount(ADDR)).rejects.toMatchObject({
+      name: 'Sep30Error',
+      status: 401,
+      message: 'authentication required',
+    })
+    await expect(client.getAccount(ADDR)).rejects.toBeInstanceOf(Sep30Error)
+  })
+
+  it('normalises a trailing slash in the base URL', async () => {
+    const fetchImpl = jsonFetch(200, { address: ADDR, identities: [], signers: [] })
+    const client = new Sep30Client({ baseUrl: `${BASE}/`, fetchImpl })
+    await client.getAccount(ADDR)
+    expect(fetchImpl.mock.calls[0][0]).toBe(`${BASE}/accounts/${ADDR}`)
+  })
+
+  it('deletes an account registration', async () => {
+    const fetchImpl = jsonFetch(200, { address: ADDR, identities: [], signers: [] })
+    const client = new Sep30Client({ baseUrl: BASE, fetchImpl })
+    await client.deleteAccount(ADDR)
+    expect(fetchImpl.mock.calls[0][1].method).toBe('DELETE')
+  })
+})
+
+describe('collectRecoverySignatures', () => {
+  it('gathers signatures from every server, tagged by signer key', async () => {
+    const mk = (sig: string, signer: string) => ({
+      client: new Sep30Client({
+        baseUrl: BASE,
+        fetchImpl: jsonFetch(200, { signature: sig, network_passphrase: 'Test SDF Network ; September 2015' }),
+      }),
+      signerKey: signer,
+    })
+    const servers = [mk('SIG_A', 'GSERVER_A'), mk('SIG_B', 'GSERVER_B')]
+
+    const sigs = await collectRecoverySignatures(servers, ADDR, 'AAAAtx==')
+
+    expect(sigs).toHaveLength(2)
+    expect(sigs.map(s => s.signerKey).sort()).toEqual(['GSERVER_A', 'GSERVER_B'])
+    expect(sigs.map(s => s.signature).sort()).toEqual(['SIG_A', 'SIG_B'])
+  })
+
+  it('rejects if any server fails when requireAll is true (default)', async () => {
+    const ok = { client: new Sep30Client({ baseUrl: BASE, fetchImpl: jsonFetch(200, { signature: 'S', network_passphrase: 'NP' }) }), signerKey: 'GOK' }
+    const bad = { client: new Sep30Client({ baseUrl: BASE, fetchImpl: jsonFetch(500, { error: 'boom' }) }), signerKey: 'GBAD' }
+    await expect(collectRecoverySignatures([ok, bad], ADDR, 'tx')).rejects.toBeInstanceOf(Sep30Error)
+  })
+
+  it('returns partial signatures when requireAll is false (M-of-N)', async () => {
+    const ok = { client: new Sep30Client({ baseUrl: BASE, fetchImpl: jsonFetch(200, { signature: 'S', network_passphrase: 'NP' }) }), signerKey: 'GOK' }
+    const bad = { client: new Sep30Client({ baseUrl: BASE, fetchImpl: jsonFetch(500, { error: 'boom' }) }), signerKey: 'GBAD' }
+    const sigs = await collectRecoverySignatures([ok, bad], ADDR, 'tx', { requireAll: false })
+    expect(sigs).toHaveLength(1)
+    expect(sigs[0].signerKey).toBe('GOK')
+  })
+})

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -1,2 +1,5 @@
 export * from './useInvisibleWallet';
 export * from './utils';
+export * from './outbox';
+export * from './webauthn/attestation';
+export * from './recovery/sep30';

--- a/sdk/src/outbox.ts
+++ b/sdk/src/outbox.ts
@@ -1,0 +1,334 @@
+/**
+ * Offline transaction outbox with reconnect replay.
+ *
+ * On flaky mobile connections a submitted transaction can be lost before it
+ * reaches the network. The outbox is a durable, persisted queue that records a
+ * fully-signed transaction *before* it is sent, then replays anything still
+ * outstanding when connectivity returns.
+ *
+ * ── At-most-once submission ──────────────────────────────────────────────────
+ * Two independent properties combine to make replay safe:
+ *
+ *   1. **Tx hash dedup.** A Stellar transaction hash is a deterministic function
+ *      of its signed envelope. Re-submitting the exact same envelope produces
+ *      the same hash, which the network rejects as a DUPLICATE. Before sending
+ *      we additionally query `getTransaction(hash)`; if the network already
+ *      knows the hash we never resend.
+ *
+ *   2. **Sequence-number dedup.** Each entry records its source-account sequence
+ *      number. Even a hypothetical re-signed transaction reusing that sequence
+ *      would be rejected by the network (`tx_bad_seq`) once the first one is
+ *      applied — so a queued transaction can be applied at most once.
+ *
+ * The outbox itself is storage-agnostic: it persists through the same
+ * {@link StorageAdapter} the wallet already uses (localStorage on web,
+ * AsyncStorage on React Native), so queued transactions survive a reload.
+ */
+
+import {
+    rpc as SorobanRpc,
+    TransactionBuilder,
+    type Transaction,
+    type FeeBumpTransaction,
+} from '@stellar/stellar-sdk';
+// Type-only import — erased at compile time, so this does not create a runtime
+// cycle with useInvisibleWallet (which imports this module).
+import type { StorageAdapter } from './useInvisibleWallet';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export type OutboxStatus = 'pending' | 'confirmed' | 'failed';
+
+/** A single queued transaction. Serialised as JSON in the storage adapter. */
+export interface OutboxEntry {
+    /** Stable identifier — the transaction hash (hex). Doubles as the dedup key. */
+    hash: string;
+    /** Source-account sequence number this transaction consumes (decimal string). */
+    sequence: string;
+    /** Base64-encoded signed transaction envelope, ready to submit as-is. */
+    xdr: string;
+    /** Network passphrase the envelope was signed for. */
+    networkPassphrase: string;
+    /** Unix epoch milliseconds when the entry was enqueued. */
+    createdAt: number;
+    /** Number of times replay has attempted to submit this entry. */
+    attempts: number;
+    /** Lifecycle status. Confirmed/failed entries are pruned from the queue. */
+    status: OutboxStatus;
+    /** Last error message, if a submission attempt failed. */
+    lastError?: string;
+}
+
+/** Outcome of a {@link TransactionOutbox.replay} pass. */
+export interface ReplayResult {
+    /** Entries confirmed on-chain during this pass (now removed from the queue). */
+    confirmed: OutboxEntry[];
+    /** Entries the network rejected/failed (now removed from the queue). */
+    failed: OutboxEntry[];
+    /** Entries still awaiting confirmation — left in the queue for a later pass. */
+    stillPending: OutboxEntry[];
+    /**
+     * Entries that were already present on-chain when replay started, i.e. the
+     * original submission *did* land. Removed from the queue without resending —
+     * this is the core at-most-once protection.
+     */
+    skippedDuplicate: OutboxEntry[];
+}
+
+/** Options controlling a replay pass. */
+export interface ReplayOptions {
+    /**
+     * When true (default) each freshly-sent transaction is polled until it
+     * leaves NOT_FOUND or the attempt budget is exhausted. When false, replay
+     * sends and returns immediately, leaving confirmation to a later pass.
+     */
+    waitForConfirmation?: boolean;
+    /** Poll interval in ms while waiting for confirmation. Default 1000. */
+    pollIntervalMs?: number;
+    /** Maximum poll attempts before giving up on confirmation. Default 30. */
+    pollMaxAttempts?: number;
+}
+
+const DEFAULT_STORAGE_KEY = 'invisible_wallet_outbox';
+const DEFAULT_POLL_INTERVAL_MS = 1_000;
+const DEFAULT_POLL_MAX_ATTEMPTS = 30;
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+/** Normalise a possibly-async StorageAdapter read into a Promise. */
+async function readItem(store: StorageAdapter, key: string): Promise<string | null> {
+    return Promise.resolve(store.getItem(key));
+}
+
+// ── Outbox ────────────────────────────────────────────────────────────────────
+
+/**
+ * A durable transaction queue backed by a {@link StorageAdapter}.
+ *
+ * @example
+ * const outbox = new TransactionOutbox(storage);
+ * // before sending, record the signed envelope:
+ * await outbox.enqueue({ hash, sequence, xdr, networkPassphrase });
+ * // on reconnect:
+ * const { confirmed, failed } = await outbox.replay(server);
+ */
+export class TransactionOutbox {
+    private readonly store: StorageAdapter;
+    private readonly key: string;
+
+    constructor(store: StorageAdapter, opts?: { key?: string }) {
+        this.store = store;
+        this.key = opts?.key ?? DEFAULT_STORAGE_KEY;
+    }
+
+    /** Read and parse the persisted queue. Returns [] if empty or corrupt. */
+    async list(): Promise<OutboxEntry[]> {
+        const raw = await readItem(this.store, this.key);
+        if (!raw) return [];
+        try {
+            const parsed = JSON.parse(raw);
+            return Array.isArray(parsed) ? (parsed as OutboxEntry[]) : [];
+        } catch {
+            // Corrupt payload — treat as empty rather than throwing on read.
+            return [];
+        }
+    }
+
+    /** Entries still awaiting confirmation, ordered by sequence number ascending. */
+    async pending(): Promise<OutboxEntry[]> {
+        const all = await this.list();
+        return all
+            .filter(e => e.status === 'pending')
+            .sort((a, b) => (BigInt(a.sequence) < BigInt(b.sequence) ? -1 : 1));
+    }
+
+    private async persist(entries: OutboxEntry[]): Promise<void> {
+        await Promise.resolve(this.store.setItem(this.key, JSON.stringify(entries)));
+    }
+
+    /**
+     * Record a signed transaction in the queue. Idempotent: enqueuing a hash
+     * that is already present updates nothing and returns the existing entry,
+     * so a retry that re-enqueues the same envelope cannot create a duplicate.
+     */
+    async enqueue(input: {
+        hash: string;
+        sequence: string | number | bigint;
+        xdr: string;
+        networkPassphrase: string;
+    }): Promise<OutboxEntry> {
+        const entries = await this.list();
+        const existing = entries.find(e => e.hash === input.hash);
+        if (existing) return existing;
+
+        const entry: OutboxEntry = {
+            hash: input.hash,
+            sequence: String(input.sequence),
+            xdr: input.xdr,
+            networkPassphrase: input.networkPassphrase,
+            createdAt: Date.now(),
+            attempts: 0,
+            status: 'pending',
+        };
+        entries.push(entry);
+        await this.persist(entries);
+        return entry;
+    }
+
+    /** Remove an entry by hash, regardless of status. */
+    async remove(hash: string): Promise<void> {
+        const entries = await this.list();
+        const next = entries.filter(e => e.hash !== hash);
+        if (next.length !== entries.length) await this.persist(next);
+    }
+
+    /** Empty the entire queue. */
+    async clear(): Promise<void> {
+        await this.persist([]);
+    }
+
+    /**
+     * Replay every pending entry against the network.
+     *
+     * For each entry, in sequence order:
+     *   1. Ask the network whether the hash is already known.
+     *      - SUCCESS → the original submission landed; drop without resending.
+     *      - FAILED  → the transaction was applied and failed; drop, do not retry
+     *        (resending the identical envelope would fail identically).
+     *      - NOT_FOUND → submit the stored envelope.
+     *   2. After submitting, optionally poll until the transaction confirms.
+     *
+     * Confirmed, failed and already-on-chain entries are pruned from the queue;
+     * entries still in flight are left for the next pass.
+     */
+    async replay(server: SorobanRpc.Server, opts?: ReplayOptions): Promise<ReplayResult> {
+        const waitForConfirmation = opts?.waitForConfirmation ?? true;
+        const pollIntervalMs = opts?.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+        const pollMaxAttempts = opts?.pollMaxAttempts ?? DEFAULT_POLL_MAX_ATTEMPTS;
+
+        const result: ReplayResult = {
+            confirmed: [],
+            failed: [],
+            stillPending: [],
+            skippedDuplicate: [],
+        };
+
+        const pending = await this.pending();
+        // Hashes to drop from the queue once the pass completes.
+        const toRemove = new Set<string>();
+        // In-place status/attempt mutations to persist back.
+        const mutations = new Map<string, Partial<OutboxEntry>>();
+
+        for (const entry of pending) {
+            // ── 1. Dedup: is the hash already known to the network? ──────────
+            try {
+                const known = await server.getTransaction(entry.hash);
+                if (known.status === SorobanRpc.Api.GetTransactionStatus.SUCCESS) {
+                    result.skippedDuplicate.push({ ...entry, status: 'confirmed' });
+                    toRemove.add(entry.hash);
+                    continue;
+                }
+                if (known.status === SorobanRpc.Api.GetTransactionStatus.FAILED) {
+                    result.failed.push({ ...entry, status: 'failed' });
+                    toRemove.add(entry.hash);
+                    continue;
+                }
+                // NOT_FOUND → fall through and submit.
+            } catch {
+                // Status lookup failed (e.g. still offline). Leave for next pass.
+                result.stillPending.push(entry);
+                continue;
+            }
+
+            // ── 2. Submit the stored envelope ────────────────────────────────
+            mutations.set(entry.hash, { attempts: entry.attempts + 1 });
+            let tx: Transaction | FeeBumpTransaction;
+            try {
+                tx = TransactionBuilder.fromXDR(entry.xdr, entry.networkPassphrase);
+            } catch (err) {
+                mutations.set(entry.hash, {
+                    attempts: entry.attempts + 1,
+                    status: 'failed',
+                    lastError: err instanceof Error ? err.message : String(err),
+                });
+                result.failed.push({ ...entry, status: 'failed' });
+                toRemove.add(entry.hash);
+                continue;
+            }
+
+            try {
+                const sendResult = await server.sendTransaction(tx);
+
+                if (sendResult.status === 'ERROR') {
+                    const msg = sendResult.errorResult?.toXDR('base64') ?? 'unknown error';
+                    mutations.set(entry.hash, {
+                        attempts: entry.attempts + 1,
+                        status: 'failed',
+                        lastError: `Transaction rejected: ${msg}`,
+                    });
+                    result.failed.push({ ...entry, status: 'failed', lastError: msg });
+                    toRemove.add(entry.hash);
+                    continue;
+                }
+
+                // 'DUPLICATE' / 'TRY_AGAIN_LATER' / 'PENDING' → still in flight.
+                if (!waitForConfirmation) {
+                    result.stillPending.push(entry);
+                    continue;
+                }
+
+                const final = await this.waitFor(server, entry.hash, pollIntervalMs, pollMaxAttempts);
+                if (final === 'SUCCESS') {
+                    result.confirmed.push({ ...entry, status: 'confirmed' });
+                    toRemove.add(entry.hash);
+                } else if (final === 'FAILED') {
+                    mutations.set(entry.hash, {
+                        attempts: entry.attempts + 1,
+                        status: 'failed',
+                        lastError: 'Transaction failed on-chain',
+                    });
+                    result.failed.push({ ...entry, status: 'failed' });
+                    toRemove.add(entry.hash);
+                } else {
+                    // Timed out waiting — keep it queued for the next pass.
+                    result.stillPending.push(entry);
+                }
+            } catch (err) {
+                // Network blip mid-send — keep queued, record the error.
+                mutations.set(entry.hash, {
+                    attempts: entry.attempts + 1,
+                    lastError: err instanceof Error ? err.message : String(err),
+                });
+                result.stillPending.push(entry);
+            }
+        }
+
+        // ── Persist the post-pass queue ──────────────────────────────────────
+        const all = await this.list();
+        const next = all
+            .filter(e => !toRemove.has(e.hash))
+            .map(e => {
+                const patch = mutations.get(e.hash);
+                return patch ? { ...e, ...patch } : e;
+            });
+        await this.persist(next);
+
+        return result;
+    }
+
+    /** Poll until the hash leaves NOT_FOUND, or attempts run out. */
+    private async waitFor(
+        server: SorobanRpc.Server,
+        hash: string,
+        intervalMs: number,
+        maxAttempts: number,
+    ): Promise<'SUCCESS' | 'FAILED' | 'TIMEOUT'> {
+        for (let i = 0; i < maxAttempts; i++) {
+            const res = await server.getTransaction(hash);
+            if (res.status === SorobanRpc.Api.GetTransactionStatus.SUCCESS) return 'SUCCESS';
+            if (res.status === SorobanRpc.Api.GetTransactionStatus.FAILED) return 'FAILED';
+            await new Promise(r => setTimeout(r, intervalMs));
+        }
+        return 'TIMEOUT';
+    }
+}

--- a/sdk/src/recovery/sep30.ts
+++ b/sdk/src/recovery/sep30.ts
@@ -1,0 +1,217 @@
+/**
+ * SEP-30 (recoverysigner) client.
+ *
+ * A SEP-30 recovery server lets a user re-establish control of an account after
+ * device loss without any single party holding the key. The account owner
+ * registers a set of *identities* (phone, email, another Stellar address, …)
+ * with one or more recovery servers; each server contributes a signer to the
+ * account. After losing their device the user re-authenticates each identity
+ * (via SEP-10, yielding a JWT), then asks the servers to sign a transaction that
+ * installs a fresh signer — re-establishing access.
+ *
+ * Spec: https://stellar.org/protocol/sep-30
+ *
+ * This client is transport-only and dependency-free: it speaks the SEP-30 REST
+ * API over `fetch` and deals in base64 transaction XDR strings, so it works
+ * unchanged in the browser, React Native, and Node. SEP-10 authentication is out
+ * of scope — supply the resulting JWT via `authToken`/`getAuthToken`.
+ */
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+/** A single authentication method for an identity (SEP-30 §"auth_methods"). */
+export interface Sep30AuthMethod {
+    /** e.g. "stellar_address", "phone_number", "email". */
+    type: string;
+    value: string;
+}
+
+/** An identity that may authenticate to recover the account. */
+export interface Sep30Identity {
+    /** e.g. "owner" or "other". */
+    role: string;
+    auth_methods: Sep30AuthMethod[];
+}
+
+/** A signer the recovery server contributes to the account. */
+export interface Sep30Signer {
+    key: string;
+    added_at?: string;
+}
+
+/** Recovery-server view of a registered account. */
+export interface Sep30Account {
+    address: string;
+    identities: Array<{ role: string; authenticated?: boolean }>;
+    signers: Sep30Signer[];
+}
+
+/** A signature returned by the recovery server for a submitted transaction. */
+export interface Sep30Signature {
+    /** Base64 signature to attach to the transaction. */
+    signature: string;
+    /** Network passphrase the signature is valid for. */
+    network_passphrase: string;
+}
+
+export interface Sep30ClientOptions {
+    /** Base URL of the recovery server, e.g. "https://recovery.example.com". */
+    baseUrl: string;
+    /** Static SEP-10 JWT. Prefer {@link getAuthToken} when the token rotates. */
+    authToken?: string;
+    /** Lazily resolve the current SEP-10 JWT (called before each request). */
+    getAuthToken?: () => string | null | undefined | Promise<string | null | undefined>;
+    /** Override the fetch implementation (defaults to the global `fetch`). */
+    fetchImpl?: typeof fetch;
+}
+
+/** Thrown when the recovery server returns a non-2xx response. */
+export class Sep30Error extends Error {
+    constructor(public readonly status: number, message: string) {
+        super(message);
+        this.name = 'Sep30Error';
+    }
+}
+
+// ── Client ──────────────────────────────────────────────────────────────────
+
+export class Sep30Client {
+    private readonly baseUrl: string;
+    private readonly opts: Sep30ClientOptions;
+    private readonly fetchImpl: typeof fetch;
+
+    constructor(opts: Sep30ClientOptions) {
+        if (!opts.baseUrl) throw new Error('Sep30Client requires a baseUrl');
+        // Normalise a trailing slash so path joins are predictable.
+        this.baseUrl = opts.baseUrl.replace(/\/+$/, '');
+        this.opts = opts;
+        const f = opts.fetchImpl ?? (typeof fetch !== 'undefined' ? fetch : undefined);
+        if (!f) throw new Error('No fetch implementation available; pass fetchImpl');
+        // Bind to avoid "Illegal invocation" when fetch is the global.
+        this.fetchImpl = f.bind(globalThis);
+    }
+
+    private async authHeader(): Promise<Record<string, string>> {
+        const token = this.opts.getAuthToken
+            ? await this.opts.getAuthToken()
+            : this.opts.authToken;
+        return token ? { Authorization: `Bearer ${token}` } : {};
+    }
+
+    private async request<T>(method: string, path: string, body?: unknown): Promise<T> {
+        const headers: Record<string, string> = {
+            Accept: 'application/json',
+            ...(await this.authHeader()),
+        };
+        if (body !== undefined) headers['Content-Type'] = 'application/json';
+
+        const res = await this.fetchImpl(`${this.baseUrl}${path}`, {
+            method,
+            headers,
+            body: body !== undefined ? JSON.stringify(body) : undefined,
+        });
+
+        const text = await res.text();
+        let parsed: unknown = undefined;
+        if (text) {
+            try { parsed = JSON.parse(text); } catch { parsed = text; }
+        }
+
+        if (!res.ok) {
+            const msg =
+                parsed && typeof parsed === 'object' && 'error' in parsed
+                    ? String((parsed as { error: unknown }).error)
+                    : `Recovery server responded ${res.status}`;
+            throw new Sep30Error(res.status, msg);
+        }
+        return parsed as T;
+    }
+
+    /**
+     * Register (or replace) the account with this recovery server.
+     *
+     * @param address    The Stellar account address ("G..." or contract "C...").
+     * @param identities The identities allowed to authenticate for recovery.
+     * @returns The registered account, including the signer the server contributes.
+     */
+    registerAccount(address: string, identities: Sep30Identity[]): Promise<Sep30Account> {
+        return this.request<Sep30Account>('POST', `/accounts/${address}`, { identities });
+    }
+
+    /** Update the identities on an already-registered account. */
+    updateAccount(address: string, identities: Sep30Identity[]): Promise<Sep30Account> {
+        return this.request<Sep30Account>('PUT', `/accounts/${address}`, { identities });
+    }
+
+    /** Fetch the recovery server's view of an account (signers, identity auth state). */
+    getAccount(address: string): Promise<Sep30Account> {
+        return this.request<Sep30Account>('GET', `/accounts/${address}`);
+    }
+
+    /** Remove the account's registration from this recovery server. */
+    deleteAccount(address: string): Promise<Sep30Account> {
+        return this.request<Sep30Account>('DELETE', `/accounts/${address}`);
+    }
+
+    /**
+     * Ask the recovery server to sign a transaction with one of its signers.
+     * The caller must already be authenticated (JWT) for an identity on the account.
+     *
+     * @param address        The account being recovered.
+     * @param signingAddress The server signer key to sign with (from {@link getAccount}).
+     * @param transactionXdr The base64-encoded transaction envelope to sign.
+     */
+    signTransaction(address: string, signingAddress: string, transactionXdr: string): Promise<Sep30Signature> {
+        return this.request<Sep30Signature>(
+            'POST',
+            `/accounts/${address}/sign/${signingAddress}`,
+            { transaction: transactionXdr },
+        );
+    }
+}
+
+// ── Multi-server helper ────────────────────────────────────────────────────────
+
+/** One recovery server participating in a recovery, paired with its signer key. */
+export interface RecoveryServer {
+    client: Sep30Client;
+    /** The server's signing address on the account (from {@link Sep30Client.getAccount}). */
+    signerKey: string;
+}
+
+/** A signature collected from a recovery server, tagged with the signer it used. */
+export interface CollectedSignature extends Sep30Signature {
+    signerKey: string;
+}
+
+/**
+ * Collect signatures for a transaction from every supplied recovery server.
+ *
+ * Requests run concurrently; if `requireAll` is true (default) any single
+ * failure rejects, otherwise failures are skipped and whatever signatures
+ * succeeded are returned (useful for an M-of-N recovery threshold).
+ *
+ * @returns The signatures gathered, each tagged with the server signer key.
+ */
+export async function collectRecoverySignatures(
+    servers: RecoveryServer[],
+    address: string,
+    transactionXdr: string,
+    opts: { requireAll?: boolean } = {},
+): Promise<CollectedSignature[]> {
+    const requireAll = opts.requireAll ?? true;
+
+    const results = await Promise.allSettled(
+        servers.map(async (s): Promise<CollectedSignature> => {
+            const sig = await s.client.signTransaction(address, s.signerKey, transactionXdr);
+            return { ...sig, signerKey: s.signerKey };
+        }),
+    );
+
+    const signatures: CollectedSignature[] = [];
+    for (const r of results) {
+        if (r.status === 'fulfilled') signatures.push(r.value);
+        else if (requireAll) throw r.reason;
+    }
+    return signatures;
+}

--- a/sdk/src/useInvisibleWallet.ts
+++ b/sdk/src/useInvisibleWallet.ts
@@ -21,6 +21,8 @@ import {
     computeWalletAddress,
 } from './utils';
 import { webAuthnProvider } from './webauthn';
+import { TransactionOutbox, type ReplayOptions, type ReplayResult } from './outbox';
+import { verifyAttestation, AttestationError, type AttestationPolicy } from './webauthn/attestation';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -64,6 +66,31 @@ export type WalletConfig = {
      * const config = { ..., storage: AsyncStorage };
      */
     storage?: StorageAdapter;
+    /**
+     * When true (default), the hook replays any transactions persisted in the
+     * offline outbox automatically whenever the browser fires an `online`
+     * event. Set to false to drive replay manually via {@link replayOutbox}.
+     * Has no effect outside a DOM environment (e.g. React Native).
+     */
+    autoReplayOnReconnect?: boolean;
+    /**
+     * Optional WebAuthn attestation policy, run during register(). When set, the
+     * attestation statement returned by the authenticator is parsed and verified,
+     * and this hook decides whether to accept the credential (e.g. require a
+     * verified hardware authenticator, or gate on AAGUID). Returning false — or
+     * throwing — from the policy aborts registration.
+     *
+     * @example
+     * const config = { ..., attestationPolicy: (info) =>
+     *   info.verified && ALLOWED_AAGUIDS.has(info.aaguid) };
+     */
+    attestationPolicy?: AttestationPolicy;
+    /**
+     * When an attestationPolicy is set but the platform did not surface the raw
+     * attestationObject (so it cannot be verified), abort registration if this is
+     * true (default false — proceed without verification).
+     */
+    requireAttestation?: boolean;
 };
 
 /**
@@ -258,6 +285,22 @@ type InvisibleWallet = {
      * @returns Object with amount and expiry, or null if no allowance exists.
      */
     getAllowance: (spender: string, token: string) => Promise<{ amount: number; expiry: number | undefined } | null>;
+    /**
+     * The durable offline transaction outbox. Record a signed transaction here
+     * (via {@link TransactionOutbox.enqueue}) before submitting it so it can be
+     * replayed if the network call is lost. Persists through the configured
+     * StorageAdapter, so queued transactions survive a reload.
+     */
+    outbox: TransactionOutbox;
+    /**
+     * Replay any transactions still queued in the offline outbox against the
+     * network. Safe to call repeatedly — already-confirmed transactions are
+     * deduped by hash and never resubmitted (at-most-once).
+     *
+     * @returns A summary of which queued transactions confirmed, failed, were
+     *          already on-chain, or remain pending.
+     */
+    replayOutbox: (opts?: ReplayOptions) => Promise<ReplayResult>;
 };
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -307,6 +350,24 @@ export function useInvisibleWallet(config: WalletConfig): InvisibleWallet {
     const [error, setError] = useState<string | null>(null);
 
     const store = useMemo(() => resolveStorage(config.storage), [config.storage]);
+    const outbox = useMemo(() => new TransactionOutbox(store), [store]);
+
+    // ── replayOutbox ────────────────────────────────────────────────────────
+    // Resubmit any transactions persisted in the offline outbox. Deduped by
+    // hash so repeated calls (and the reconnect listener below) are safe.
+    const replayOutbox = useCallback(async (opts?: ReplayOptions): Promise<ReplayResult> => {
+        const server = new SorobanRpc.Server(rpcUrl);
+        return outbox.replay(server, opts);
+    }, [rpcUrl, outbox]);
+
+    // Auto-replay when connectivity returns. No-op outside the browser.
+    useEffect(() => {
+        if (config.autoReplayOnReconnect === false) return;
+        if (typeof window === 'undefined' || typeof window.addEventListener !== 'function') return;
+        const onOnline = () => { void replayOutbox().catch(() => { /* surfaced via per-entry status */ }); };
+        window.addEventListener('online', onOnline);
+        return () => window.removeEventListener('online', onOnline);
+    }, [config.autoReplayOnReconnect, replayOutbox]);
 
     useEffect(() => {
         // Support both synchronous (localStorage) and asynchronous (AsyncStorage) adapters.
@@ -335,13 +396,28 @@ export function useInvisibleWallet(config: WalletConfig): InvisibleWallet {
 
             const resolvedRpId = rpId ?? (typeof window !== 'undefined' ? window.location.hostname : 'localhost');
 
-            const { credentialId, publicKeyBytes } = await webAuthnProvider.create({
+            const { credentialId, publicKeyBytes, attestationObject, clientDataJSON } = await webAuthnProvider.create({
                 challenge,
                 rpId:     resolvedRpId,
                 rpName:   'Invisible Wallet',
                 userId,
                 userName: name,
             });
+
+            // Optional attestation verification — enforce authenticator policy.
+            if (config.attestationPolicy) {
+                if (attestationObject && clientDataJSON) {
+                    await verifyAttestation({
+                        attestationObject,
+                        clientDataJSON,
+                        policy: config.attestationPolicy,
+                    });
+                } else if (config.requireAttestation) {
+                    throw new AttestationError(
+                        'Attestation required but the platform did not expose an attestationObject.'
+                    );
+                }
+            }
 
             const publicKeyHex  = bufferToHex(publicKeyBytes);
             const walletAddress = computeWalletAddress(factoryAddress, publicKeyBytes, networkPassphrase);
@@ -361,7 +437,7 @@ export function useInvisibleWallet(config: WalletConfig): InvisibleWallet {
         } finally {
             setIsPending(false);
         }
-    }, [factoryAddress, networkPassphrase, rpId, store]);
+    }, [factoryAddress, networkPassphrase, rpId, store, config.attestationPolicy, config.requireAttestation]);
 
     // ── deploy ────────────────────────────────────────────────────────────────
 
@@ -1196,6 +1272,6 @@ export function useInvisibleWallet(config: WalletConfig): InvisibleWallet {
     }, [address, rpcUrl, networkPassphrase, signAuthEntry]);
 
     return useMemo(() => (
-        { address, isDeployed, isPending, error, register, deploy, signAuthEntry, login, getNonce, addSigner, removeSigner, getSigners, setGuardian, initiateRecovery, completeRecovery, approve, getAllowance }
-    ), [address, isDeployed, isPending, error, register, deploy, signAuthEntry, login, getNonce, addSigner, removeSigner, getSigners, setGuardian, initiateRecovery, completeRecovery, approve, getAllowance]);
+        { address, isDeployed, isPending, error, register, deploy, signAuthEntry, login, getNonce, addSigner, removeSigner, getSigners, setGuardian, initiateRecovery, completeRecovery, approve, getAllowance, outbox, replayOutbox }
+    ), [address, isDeployed, isPending, error, register, deploy, signAuthEntry, login, getNonce, addSigner, removeSigner, getSigners, setGuardian, initiateRecovery, completeRecovery, approve, getAllowance, outbox, replayOutbox]);
 }

--- a/sdk/src/webauthn.native.ts
+++ b/sdk/src/webauthn.native.ts
@@ -91,7 +91,17 @@ export const webAuthnProvider: WebAuthnProvider = {
         const spkiBytes = b64urlToUint8Array(publicKeyB64);
         const publicKeyBytes = spkiToP256Uncompressed(spkiBytes);
 
-        return { credentialId: result.id, publicKeyBytes };
+        // react-native-passkey may expose the raw attestation when configured to;
+        // pass it through when present so callers can verify it at registration.
+        const rawAttestation: string | undefined = result.response.attestationObject;
+        const rawClientData:  string | undefined = result.response.clientDataJSON;
+
+        return {
+            credentialId: result.id,
+            publicKeyBytes,
+            attestationObject: rawAttestation ? b64urlToUint8Array(rawAttestation) : undefined,
+            clientDataJSON:    rawClientData  ? b64urlToUint8Array(rawClientData)  : undefined,
+        };
     },
 
     async authenticate({ challenge, credentialId, rpId }): Promise<WebAuthnAssertResult> {

--- a/sdk/src/webauthn.ts
+++ b/sdk/src/webauthn.ts
@@ -14,6 +14,14 @@ export interface WebAuthnCreateResult {
     credentialId: string;
     /** Uncompressed P-256 public key: 0x04 ‖ x ‖ y (65 bytes). */
     publicKeyBytes: Uint8Array;
+    /**
+     * Raw CBOR attestationObject bytes, when the platform exposes them. Required
+     * to verify the attestation statement at registration; may be undefined on
+     * platforms that do not surface it.
+     */
+    attestationObject?: Uint8Array;
+    /** Raw clientDataJSON bytes from the registration response, when available. */
+    clientDataJSON?: Uint8Array;
 }
 
 export interface WebAuthnAssertResult {
@@ -72,7 +80,12 @@ export const webAuthnProvider: WebAuthnProvider = {
         const response = credential.response as AuthenticatorAttestationResponse;
         const publicKeyBytes = await extractP256PublicKey(response);
 
-        return { credentialId: credential.id, publicKeyBytes };
+        return {
+            credentialId: credential.id,
+            publicKeyBytes,
+            attestationObject: new Uint8Array(response.attestationObject),
+            clientDataJSON:    new Uint8Array(response.clientDataJSON),
+        };
     },
 
     async authenticate({ challenge, credentialId, rpId }) {

--- a/sdk/src/webauthn/attestation.ts
+++ b/sdk/src/webauthn/attestation.ts
@@ -1,0 +1,432 @@
+/**
+ * WebAuthn attestation verification at registration.
+ *
+ * Verifying the attestation statement returned by `navigator.credentials.create()`
+ * lets a relying party enforce authenticator provenance and policy — for example,
+ * requiring a hardware authenticator or rejecting a known-weak AAGUID.
+ *
+ * This module supports the two most common attestation formats:
+ *
+ *   - **`none`**   — no statement; nothing to verify cryptographically, but the
+ *                    AAGUID and credential public key are still parsed so a policy
+ *                    can inspect them.
+ *   - **`packed`** — the FIDO2 default. Two sub-cases:
+ *       - *self attestation* (no `x5c`): the statement is signed by the
+ *         credential's own private key. Fully verified here against the public
+ *         key embedded in `authData`.
+ *       - *basic/full attestation* (`x5c` present): signed by an attestation
+ *         certificate. The signature is verified against the leaf certificate's
+ *         public key.
+ *
+ * ── Trade-offs (deliberately out of scope) ───────────────────────────────────
+ * For `x5c` (basic) attestation this module verifies the statement signature
+ * against the **leaf certificate**, but does NOT walk the certificate chain to a
+ * trusted FIDO Metadata Service (MDS) root. Full chain-to-root validation
+ * requires shipping and maintaining a root store, which is an application-level
+ * policy decision. Callers who need it should perform chain validation inside
+ * their {@link AttestationPolicy} using the parsed certificates. Treating a
+ * self-signed `packed` statement as proof of provenance is also weaker than a
+ * full chain — the policy hook is where you encode how much you trust each case.
+ */
+
+// ── Errors ──────────────────────────────────────────────────────────────────
+
+/** Thrown when the attestation object cannot be parsed or its signature is invalid. */
+export class AttestationError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'AttestationError';
+    }
+}
+
+/** Thrown when a caller-supplied {@link AttestationPolicy} rejects the credential. */
+export class AttestationPolicyError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'AttestationPolicyError';
+    }
+}
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+/** How the attestation statement was (or was not) cryptographically verified. */
+export type AttestationType = 'self' | 'basic' | 'none' | 'unsupported';
+
+/** Parsed, optionally-verified attestation details handed to a policy. */
+export interface AttestationInfo {
+    /** Attestation statement format, e.g. "packed" or "none". */
+    fmt: string;
+    /** Authenticator AAGUID as a lowercase hex string (32 chars), or "" if absent. */
+    aaguid: string;
+    /** Raw 16-byte AAGUID. */
+    aaguidBytes: Uint8Array;
+    /** The newly-created credential ID. */
+    credentialId: Uint8Array;
+    /** Uncompressed P-256 public key (0x04 ‖ x ‖ y) from authData, if EC2/ES256. */
+    publicKey?: Uint8Array;
+    /** Authenticator signature counter. */
+    signCount: number;
+    /** Whether a cryptographic attestation statement was present and verified. */
+    verified: boolean;
+    /** Verification method used to produce {@link verified}. */
+    attestationType: AttestationType;
+    /** Raw DER leaf attestation certificate, when the format includes an x5c chain. */
+    leafCert?: Uint8Array;
+}
+
+/**
+ * A policy callback run after parsing/verification. Return `false` (or throw) to
+ * reject the registration; return `true`/`undefined` to accept. Use it to gate
+ * on {@link AttestationInfo.aaguid}, {@link AttestationInfo.fmt}, or whether the
+ * statement {@link AttestationInfo.verified | verified}.
+ *
+ * @example
+ * // Require a verified hardware authenticator from an allow-list of AAGUIDs.
+ * const policy: AttestationPolicy = (info) =>
+ *   info.verified && ALLOWED_AAGUIDS.has(info.aaguid);
+ */
+export type AttestationPolicy = (info: AttestationInfo) => boolean | void | Promise<boolean | void>;
+
+export interface VerifyAttestationOptions {
+    /** Raw `AuthenticatorAttestationResponse.attestationObject` bytes. */
+    attestationObject: Uint8Array | ArrayBuffer;
+    /** Raw `AuthenticatorAttestationResponse.clientDataJSON` bytes. */
+    clientDataJSON: Uint8Array | ArrayBuffer;
+    /** Optional policy hook; rejection throws {@link AttestationPolicyError}. */
+    policy?: AttestationPolicy;
+    /**
+     * When true (default), a `packed` statement whose signature fails to verify
+     * throws {@link AttestationError}. Set false to record `verified: false`
+     * and defer the decision to the policy instead.
+     */
+    requireValidSignature?: boolean;
+}
+
+// ── Minimal CBOR decoder (attestation subset) ──────────────────────────────────
+//
+// Supports the CBOR major types that appear in a WebAuthn attestationObject and
+// COSE key: unsigned/negative ints, byte/text strings, arrays, maps, and the
+// false/true/null simple values. Indefinite-length items and floats are not used
+// by WebAuthn and are intentionally unsupported.
+
+function toUint8(input: Uint8Array | ArrayBuffer): Uint8Array {
+    return input instanceof Uint8Array ? input : new Uint8Array(input);
+}
+
+interface CborResult { value: unknown; bytesRead: number }
+
+function decodeCbor(bytes: Uint8Array, start = 0): CborResult {
+    let offset = start;
+
+    function readLength(info: number): number {
+        if (info < 24) return info;
+        if (info === 24) return bytes[offset++];
+        if (info === 25) { const v = (bytes[offset] << 8) | bytes[offset + 1]; offset += 2; return v; }
+        if (info === 26) {
+            const v = ((bytes[offset] << 24) | (bytes[offset + 1] << 16) | (bytes[offset + 2] << 8) | bytes[offset + 3]) >>> 0;
+            offset += 4; return v;
+        }
+        if (info === 27) {
+            // 8-byte length; WebAuthn values fit comfortably in a JS number.
+            let v = 0;
+            for (let i = 0; i < 8; i++) v = v * 256 + bytes[offset + i];
+            offset += 8; return v;
+        }
+        throw new AttestationError('CBOR: unsupported length encoding');
+    }
+
+    function decodeItem(): unknown {
+        const initial = bytes[offset++];
+        const major = initial >> 5;
+        const info = initial & 0x1f;
+        switch (major) {
+            case 0: return readLength(info);                 // unsigned int
+            case 1: return -1 - readLength(info);            // negative int
+            case 2: {                                        // byte string
+                const len = readLength(info);
+                const v = bytes.slice(offset, offset + len); offset += len; return v;
+            }
+            case 3: {                                        // text string
+                const len = readLength(info);
+                const v = new TextDecoder().decode(bytes.slice(offset, offset + len)); offset += len; return v;
+            }
+            case 4: {                                        // array
+                const len = readLength(info);
+                const arr: unknown[] = [];
+                for (let i = 0; i < len; i++) arr.push(decodeItem());
+                return arr;
+            }
+            case 5: {                                        // map
+                const len = readLength(info);
+                const m = new Map<unknown, unknown>();
+                for (let i = 0; i < len; i++) { const k = decodeItem(); m.set(k, decodeItem()); }
+                return m;
+            }
+            case 7:
+                if (info === 20) return false;
+                if (info === 21) return true;
+                if (info === 22) return null;
+                if (info === 23) return undefined;
+                throw new AttestationError('CBOR: unsupported simple value');
+            default:
+                throw new AttestationError(`CBOR: unsupported major type ${major}`);
+        }
+    }
+
+    const value = decodeItem();
+    return { value, bytesRead: offset - start };
+}
+
+// ── authData parsing ───────────────────────────────────────────────────────────
+
+interface ParsedAuthData {
+    rpIdHash: Uint8Array;
+    flags: number;
+    signCount: number;
+    aaguid: Uint8Array;
+    credentialId: Uint8Array;
+    publicKey?: Uint8Array;   // uncompressed P-256, if EC2/ES256
+}
+
+const AT_FLAG = 0x40; // attested credential data present
+
+/** Reconstruct the uncompressed P-256 point from a COSE EC2 key map. */
+function coseToUncompressedP256(cose: Map<unknown, unknown>): Uint8Array | undefined {
+    if (cose.get(1) !== 2) return undefined;          // kty must be EC2 (2)
+    const x = cose.get(-2);
+    const y = cose.get(-3);
+    if (!(x instanceof Uint8Array) || !(y instanceof Uint8Array) || x.length !== 32 || y.length !== 32) {
+        return undefined;
+    }
+    const out = new Uint8Array(65);
+    out[0] = 0x04;
+    out.set(x, 1);
+    out.set(y, 33);
+    return out;
+}
+
+function parseAuthData(authData: Uint8Array): ParsedAuthData {
+    if (authData.length < 37) throw new AttestationError('authData too short (< 37 bytes)');
+    const view = new DataView(authData.buffer, authData.byteOffset, authData.byteLength);
+
+    const rpIdHash = authData.slice(0, 32);
+    const flags = view.getUint8(32);
+    const signCount = view.getUint32(33, false);
+
+    let aaguid = new Uint8Array(16);
+    let credentialId = new Uint8Array(0);
+    let publicKey: Uint8Array | undefined;
+
+    if (flags & AT_FLAG) {
+        if (authData.length < 55) throw new AttestationError('authData missing attested credential data');
+        aaguid = authData.slice(37, 53);
+        const credIdLen = view.getUint16(53, false);
+        const credIdStart = 55;
+        const credIdEnd = credIdStart + credIdLen;
+        if (authData.length < credIdEnd) throw new AttestationError('authData credentialId length out of range');
+        credentialId = authData.slice(credIdStart, credIdEnd);
+
+        // The COSE public key is CBOR immediately following the credential ID.
+        const { value } = decodeCbor(authData, credIdEnd);
+        if (value instanceof Map) publicKey = coseToUncompressedP256(value);
+    }
+
+    return { rpIdHash, flags, signCount, aaguid, credentialId, publicKey };
+}
+
+// ── DER helpers (ECDSA signature + X.509 SPKI extraction) ───────────────────────
+
+/** Convert a DER-encoded ECDSA signature to raw r‖s (64 bytes), no low-S normalisation. */
+function derEcdsaToRaw(der: Uint8Array): Uint8Array {
+    if (der[0] !== 0x30) throw new AttestationError('DER: expected SEQUENCE');
+    let offset = 2;
+    // Handle a long-form length byte on the outer SEQUENCE.
+    if (der[1] & 0x80) offset = 2 + (der[1] & 0x7f);
+
+    if (der[offset] !== 0x02) throw new AttestationError('DER: expected INTEGER (r)');
+    const rLen = der[offset + 1];
+    const r = der.slice(offset + 2, offset + 2 + rLen);
+    offset = offset + 2 + rLen;
+
+    if (der[offset] !== 0x02) throw new AttestationError('DER: expected INTEGER (s)');
+    const sLen = der[offset + 1];
+    const s = der.slice(offset + 2, offset + 2 + sLen);
+
+    const pad32 = (b: Uint8Array): Uint8Array => {
+        let i = 0;
+        while (i < b.length - 32 && b[i] === 0) i++;   // strip leading sign byte(s)
+        const trimmed = b.slice(i);
+        const out = new Uint8Array(32);
+        out.set(trimmed, 32 - trimmed.length);
+        return out;
+    };
+
+    const raw = new Uint8Array(64);
+    raw.set(pad32(r), 0);
+    raw.set(pad32(s), 32);
+    return raw;
+}
+
+/** Read one DER TLV at `off`, returning its content/end byte offsets. */
+function readTLV(buf: Uint8Array, off: number): { tag: number; contentStart: number; contentEnd: number; end: number } {
+    const tag = buf[off];
+    let lenByte = buf[off + 1];
+    let contentStart = off + 2;
+    let length: number;
+    if (lenByte & 0x80) {
+        const numBytes = lenByte & 0x7f;
+        length = 0;
+        for (let i = 0; i < numBytes; i++) length = (length << 8) | buf[off + 2 + i];
+        contentStart = off + 2 + numBytes;
+    } else {
+        length = lenByte;
+    }
+    const contentEnd = contentStart + length;
+    return { tag, contentStart, contentEnd, end: contentEnd };
+}
+
+/**
+ * Extract the SubjectPublicKeyInfo (SPKI) DER from an X.509 certificate so it can
+ * be imported via `crypto.subtle.importKey('spki', ...)`.
+ *
+ * Certificate ::= SEQUENCE { tbsCertificate, signatureAlgorithm, signatureValue }
+ * tbsCertificate ::= SEQUENCE { [0] version?, serialNumber, signature, issuer,
+ *                               validity, subject, subjectPublicKeyInfo, ... }
+ */
+function extractSpkiFromCert(cert: Uint8Array): Uint8Array {
+    const certSeq = readTLV(cert, 0);
+    if (certSeq.tag !== 0x30) throw new AttestationError('x5c: certificate is not a SEQUENCE');
+    const tbs = readTLV(cert, certSeq.contentStart);
+    if (tbs.tag !== 0x30) throw new AttestationError('x5c: tbsCertificate is not a SEQUENCE');
+
+    let cursor = tbs.contentStart;
+    // Optional explicit [0] version tag.
+    let first = readTLV(cert, cursor);
+    if (first.tag === 0xa0) cursor = first.end;       // skip version
+    // Skip serialNumber, signature, issuer, validity, subject (5 elements).
+    for (let i = 0; i < 5; i++) cursor = readTLV(cert, cursor).end;
+    const spki = readTLV(cert, cursor);
+    if (spki.tag !== 0x30) throw new AttestationError('x5c: could not locate SubjectPublicKeyInfo');
+    return cert.slice(cursor, spki.end);
+}
+
+// ── Signature verification ─────────────────────────────────────────────────────
+
+async function sha256(data: Uint8Array): Promise<Uint8Array> {
+    const buf = await crypto.subtle.digest(
+        'SHA-256',
+        data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength) as ArrayBuffer,
+    );
+    return new Uint8Array(buf);
+}
+
+/** Verify a packed-format ECDSA P-256 signature over (authData ‖ clientDataHash). */
+async function verifyPackedSignature(
+    spkiOrRawKey: Uint8Array,
+    keyFormat: 'spki' | 'raw',
+    authData: Uint8Array,
+    clientDataHash: Uint8Array,
+    sigDer: Uint8Array,
+): Promise<boolean> {
+    const signedData = new Uint8Array(authData.length + clientDataHash.length);
+    signedData.set(authData, 0);
+    signedData.set(clientDataHash, authData.length);
+
+    const key = await crypto.subtle.importKey(
+        keyFormat,
+        spkiOrRawKey.buffer.slice(spkiOrRawKey.byteOffset, spkiOrRawKey.byteOffset + spkiOrRawKey.byteLength) as ArrayBuffer,
+        { name: 'ECDSA', namedCurve: 'P-256' },
+        false,
+        ['verify'],
+    );
+
+    const rawSig = derEcdsaToRaw(sigDer);
+    return crypto.subtle.verify(
+        { name: 'ECDSA', hash: 'SHA-256' },
+        key,
+        rawSig.buffer.slice(rawSig.byteOffset, rawSig.byteOffset + rawSig.byteLength) as ArrayBuffer,
+        signedData.buffer.slice(signedData.byteOffset, signedData.byteOffset + signedData.byteLength) as ArrayBuffer,
+    );
+}
+
+// ── Public API ─────────────────────────────────────────────────────────────────
+
+/**
+ * Parse and (where possible) verify a WebAuthn attestation statement, then apply
+ * an optional policy.
+ *
+ * @throws {AttestationError}        if the object can't be parsed, or a packed
+ *                                   signature is invalid and `requireValidSignature`.
+ * @throws {AttestationPolicyError}  if the policy returns `false` or throws.
+ */
+export async function verifyAttestation(opts: VerifyAttestationOptions): Promise<AttestationInfo> {
+    const requireValidSignature = opts.requireValidSignature ?? true;
+    const attBytes = toUint8(opts.attestationObject);
+    const clientDataBytes = toUint8(opts.clientDataJSON);
+
+    const { value: decoded } = decodeCbor(attBytes);
+    if (!(decoded instanceof Map)) throw new AttestationError('attestationObject is not a CBOR map');
+
+    const fmt = decoded.get('fmt');
+    const attStmt = decoded.get('attStmt');
+    const authDataRaw = decoded.get('authData');
+    if (typeof fmt !== 'string') throw new AttestationError('attestationObject missing fmt');
+    if (!(authDataRaw instanceof Uint8Array)) throw new AttestationError('attestationObject missing authData');
+
+    const parsed = parseAuthData(authDataRaw);
+
+    const info: AttestationInfo = {
+        fmt,
+        aaguid: Array.from(parsed.aaguid).map(b => b.toString(16).padStart(2, '0')).join(''),
+        aaguidBytes: parsed.aaguid,
+        credentialId: parsed.credentialId,
+        publicKey: parsed.publicKey,
+        signCount: parsed.signCount,
+        verified: false,
+        attestationType: 'unsupported',
+    };
+
+    if (fmt === 'none') {
+        info.attestationType = 'none';
+        info.verified = false; // nothing to verify; provenance is unattested
+    } else if (fmt === 'packed' && attStmt instanceof Map) {
+        const sig = attStmt.get('sig');
+        const x5c = attStmt.get('x5c');
+        if (!(sig instanceof Uint8Array)) throw new AttestationError('packed attStmt missing sig');
+
+        const clientDataHash = await sha256(clientDataBytes);
+
+        if (Array.isArray(x5c) && x5c.length > 0 && x5c[0] instanceof Uint8Array) {
+            // Basic / full attestation — verify against the leaf certificate.
+            info.attestationType = 'basic';
+            info.leafCert = x5c[0] as Uint8Array;
+            const spki = extractSpkiFromCert(x5c[0] as Uint8Array);
+            info.verified = await verifyPackedSignature(spki, 'spki', authDataRaw, clientDataHash, sig);
+        } else if (parsed.publicKey) {
+            // Self attestation — verify against the credential's own public key.
+            info.attestationType = 'self';
+            info.verified = await verifyPackedSignature(parsed.publicKey, 'raw', authDataRaw, clientDataHash, sig);
+        } else {
+            throw new AttestationError('packed attestation has neither x5c nor a usable credential key');
+        }
+
+        if (!info.verified && requireValidSignature) {
+            throw new AttestationError(`packed attestation signature failed to verify (${info.attestationType})`);
+        }
+    } else {
+        // Unsupported format (e.g. "tpm", "android-key", "apple"). Parse-only.
+        info.attestationType = 'unsupported';
+        info.verified = false;
+    }
+
+    if (opts.policy) {
+        const verdict = await opts.policy(info);
+        if (verdict === false) {
+            throw new AttestationPolicyError(
+                `Attestation rejected by policy (fmt=${info.fmt}, aaguid=${info.aaguid || 'none'}, verified=${info.verified})`,
+            );
+        }
+    }
+
+    return info;
+}


### PR DESCRIPTION
▎ Closes #279 
    Closes #280
    Closes #281
     Closes #282.
▎
▎ #279 — Reproducible WASM build verification in CI
▎
▎ - scripts/reproducible-build.sh: builds contracts in the pinned rust:1.85.0-bookworm image (repo mounted at a fixed /work path, --locked deps) and verifies release WASM SHA-256 against committed hashes. Supports --update and --no-docker.
▎ - contracts/expected-hashes.json: genuine hashes, generated from two independent builds that matched byte-for-byte.
▎ - .github/workflows/reproducible-build.yml: verifies against committed hashes and builds twice to assert determinism (fails CI on drift).
▎ - Docs: docs/reproducible-build.md + README "Verifying contract builds" section explain third-party reproduction.
▎ - Deterministic across runs · CI fails on drift · documented.
▎
▎ #280 — SEP-30 server-assisted recovery
▎
▎ - sdk/src/recovery/sep30.ts: Sep30Client (register/update/sign/details) + collectRecoverySignatures() to gather co-signatures from multiple recovery servers.
▎ - Wired into frontend/wallet/lib/recovery.ts to complement the existing self-custodial mnemonic backup — no single party holds the key.
▎
▎ #281 — Offline transaction queue with reconnect replay
▎
▎ - sdk/src/outbox.ts: durable TransactionOutbox that records a signed tx before submission and replays outstanding ones on reconnect.
▎ - At-most-once: deduped by tx hash and source-account sequence; checks getTransaction(hash) before any resend.
▎ - Exposed via the hook as outbox + replayOutbox(), with optional auto-replay on the browser online event.
▎
▎ #282 — WebAuthn attestation verification at registration
▎
▎ - sdk/src/webauthn/attestation.ts: parses/verifies the attestationObject (packed self/basic + none), exposes AttestationInfo (AAGUID, sign count, type, verified).
▎ - Web + native providers now surface raw attestationObject/clientDataJSON; register() enforces an optional attestationPolicy.
▎
▎ Testing
▎
▎ - SDK: 55/55 Jest tests pass (incl. new outbox, sep30, attestation suites); tsc --noEmit clean.
▎ - Reproducible build verified via two independent Docker builds with matching hashes.
▎
