### PR TITLE
Roaming FIDO2 security-key support (cross-platform authenticators)

### DIFF
--- a/sdk/src/__tests__/roaming-fido2.test.ts
+++ b/sdk/src/__tests__/roaming-fido2.test.ts
@@ -1,0 +1,282 @@
+/**
+ * Tests for roaming FIDO2 security-key support (cross-platform authenticators).
+ *
+ * Covers both the WebAuthn provider (registration/assertion option plumbing) and
+ * the useInvisibleWallet hook (persisting a roaming credential as a portable
+ * signer, independent of platform passkeys, and replaying its transports when
+ * signing from another device).
+ */
+
+import { renderHook, act } from '@testing-library/react'
+import { useInvisibleWallet } from '../useInvisibleWallet'
+import { webAuthnProvider } from '../webauthn'
+
+// ── @stellar/stellar-sdk mock ─────────────────────────────────────────────────
+// Mirrors useInvisibleWallet.test.ts — no real network calls are made.
+
+jest.mock('@stellar/stellar-sdk', () => ({
+  Networks: {
+    TESTNET: 'Test SDF Network ; September 2015',
+    PUBLIC:  'Public Global Stellar Network ; September 2015',
+  },
+  BASE_FEE: '100',
+  rpc: {
+    Server: jest.fn().mockImplementation(() => ({
+      getContractData:     jest.fn().mockResolvedValue({}),
+      simulateTransaction: jest.fn().mockResolvedValue({ result: { retval: {} } }),
+      sendTransaction:     jest.fn().mockResolvedValue({ status: 'PENDING', hash: 'mock-hash' }),
+      getTransaction:      jest.fn().mockResolvedValue({ status: 'SUCCESS' }),
+    })),
+    Api: {
+      GetTransactionStatus: { SUCCESS: 'SUCCESS', NOT_FOUND: 'NOT_FOUND', FAILED: 'FAILED' },
+      isSimulationError: jest.fn(() => false),
+    },
+    Durability: { Persistent: 'persistent' },
+    assembleTransaction: jest.fn().mockReturnValue({
+      build: jest.fn().mockReturnValue({ sign: jest.fn(), toXDR: jest.fn() }),
+    }),
+  },
+  Horizon: { Server: jest.fn() },
+  Account: jest.fn(),
+  Contract: jest.fn().mockImplementation(() => ({ call: jest.fn() })),
+  Keypair: { random: jest.fn(), fromSecret: jest.fn() },
+  TransactionBuilder: jest.fn(),
+  xdr: { ScVal: { scvLedgerKeyContractInstance: jest.fn() } },
+  nativeToScVal: jest.fn(),
+  scValToNative: jest.fn(),
+  Asset: { native: jest.fn() },
+}))
+
+// ── ./utils mock ──────────────────────────────────────────────────────────────
+
+jest.mock('../utils', () => ({
+  bufferToHex:          jest.fn(() => 'deadbeef'),
+  hexToUint8Array:      jest.fn(() => new Uint8Array(65).fill(4)),
+  derToRawSignature:    jest.fn(() => new Uint8Array(64).fill(1)),
+  extractP256PublicKey: jest.fn().mockResolvedValue(new Uint8Array(65).fill(4)),
+  computeWalletAddress: jest.fn(() => 'CWALLET_ADDRESS_MOCK'),
+}))
+
+// ── WebAuthn + crypto mocks ───────────────────────────────────────────────────
+
+const mockCredentialsCreate = jest.fn()
+const mockCredentialsGet    = jest.fn()
+
+Object.defineProperty(global, 'navigator', {
+  value: { credentials: { create: mockCredentialsCreate, get: mockCredentialsGet } },
+  writable: true,
+  configurable: true,
+})
+
+Object.defineProperty(global, 'crypto', {
+  value: { getRandomValues: jest.fn((arr: Uint8Array) => (arr.fill(42), arr)) },
+  writable: true,
+  configurable: true,
+})
+
+const CONFIG = {
+  factoryAddress:    'CFACTORY_ADDRESS',
+  rpcUrl:            'https://soroban-testnet.stellar.org',
+  networkPassphrase: 'Test SDF Network ; September 2015',
+}
+
+/** A roaming security-key registration credential (cross-platform attachment). */
+function makeRoamingRegistrationCredential() {
+  return {
+    id:   'cm9hbWluZy1rZXktaWQ',
+    type: 'public-key',
+    authenticatorAttachment: 'cross-platform',
+    response: {
+      attestationObject: new ArrayBuffer(32),
+      clientDataJSON:    new ArrayBuffer(32),
+      getTransports:     jest.fn(() => ['usb', 'nfc']),
+    },
+  }
+}
+
+/** A platform passkey registration credential (device-bound). */
+function makePlatformRegistrationCredential() {
+  return {
+    id:   'cGxhdGZvcm0ta2V5LWlk',
+    type: 'public-key',
+    authenticatorAttachment: 'platform',
+    response: {
+      attestationObject: new ArrayBuffer(32),
+      clientDataJSON:    new ArrayBuffer(32),
+      getTransports:     jest.fn(() => ['internal']),
+    },
+  }
+}
+
+function makeAssertionCredential() {
+  return {
+    id:   'cm9hbWluZy1rZXktaWQ',
+    type: 'public-key',
+    response: {
+      authenticatorData: new ArrayBuffer(37),
+      clientDataJSON:    new ArrayBuffer(64),
+      signature:         new ArrayBuffer(72),
+      userHandle:        null,
+    },
+  }
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  localStorage.clear()
+})
+
+// ── WebAuthn provider: cross-platform attachment options ──────────────────────
+
+describe('webAuthnProvider — cross-platform attachment options', () => {
+  it('requests a cross-platform authenticator and a resident credential when roaming', async () => {
+    mockCredentialsCreate.mockResolvedValueOnce(makeRoamingRegistrationCredential())
+
+    await webAuthnProvider.create({
+      challenge: new Uint8Array(32),
+      rpId:      'localhost',
+      rpName:    'Invisible Wallet',
+      userId:    new Uint8Array(16),
+      userName:  'alice',
+      authenticatorAttachment: 'cross-platform',
+    })
+
+    const opts = mockCredentialsCreate.mock.calls[0][0].publicKey
+    expect(opts.authenticatorSelection.authenticatorAttachment).toBe('cross-platform')
+    expect(opts.authenticatorSelection.residentKey).toBe('required')
+  })
+
+  it('does not pin an attachment and prefers a resident key for a default (platform) credential', async () => {
+    mockCredentialsCreate.mockResolvedValueOnce(makePlatformRegistrationCredential())
+
+    await webAuthnProvider.create({
+      challenge: new Uint8Array(32),
+      rpId:      'localhost',
+      rpName:    'Invisible Wallet',
+      userId:    new Uint8Array(16),
+      userName:  'alice',
+    })
+
+    const opts = mockCredentialsCreate.mock.calls[0][0].publicKey
+    expect(opts.authenticatorSelection.authenticatorAttachment).toBeUndefined()
+    expect(opts.authenticatorSelection.residentKey).toBe('preferred')
+  })
+
+  it('reports the attachment and transports from the registration response', async () => {
+    mockCredentialsCreate.mockResolvedValueOnce(makeRoamingRegistrationCredential())
+
+    const result = await webAuthnProvider.create({
+      challenge: new Uint8Array(32),
+      rpId:      'localhost',
+      rpName:    'Invisible Wallet',
+      userId:    new Uint8Array(16),
+      userName:  'alice',
+      authenticatorAttachment: 'cross-platform',
+    })
+
+    expect(result.authenticatorAttachment).toBe('cross-platform')
+    expect(result.transports).toEqual(['usb', 'nfc'])
+  })
+
+  it('forwards stored transports to allowCredentials on assertion', async () => {
+    mockCredentialsGet.mockResolvedValueOnce(makeAssertionCredential())
+
+    await webAuthnProvider.authenticate({
+      challenge:    new ArrayBuffer(32),
+      credentialId: 'cm9hbWluZy1rZXktaWQ',
+      transports:   ['usb', 'nfc'],
+    })
+
+    const opts = mockCredentialsGet.mock.calls[0][0].publicKey
+    expect(opts.allowCredentials[0].transports).toEqual(['usb', 'nfc'])
+  })
+})
+
+// ── Hook: portable signer persistence + signing ───────────────────────────────
+
+describe('useInvisibleWallet — roaming key as a portable signer', () => {
+  it('persists a roaming credential as a portable signer independent of platform passkeys', async () => {
+    mockCredentialsCreate.mockResolvedValueOnce(makeRoamingRegistrationCredential())
+
+    const { result } = renderHook(() => useInvisibleWallet(CONFIG))
+
+    let registerResult!: Awaited<ReturnType<typeof result.current.register>>
+    await act(async () => {
+      registerResult = await result.current.register('alice', { authenticatorAttachment: 'cross-platform' })
+    })
+
+    expect(registerResult!.isPortableSigner).toBe(true)
+    expect(registerResult!.authenticatorAttachment).toBe('cross-platform')
+
+    // Stored under a dedicated key, separate from the platform-passkey keys.
+    const stored = localStorage.getItem('invisible_wallet_portable_signer')
+    expect(stored).not.toBeNull()
+    const parsed = JSON.parse(stored!)
+    expect(parsed.authenticatorAttachment).toBe('cross-platform')
+    expect(parsed.transports).toEqual(['usb', 'nfc'])
+    expect(parsed.credentialId).toBe('cm9hbWluZy1rZXktaWQ')
+  })
+
+  it('does not persist a portable signer for a platform passkey', async () => {
+    mockCredentialsCreate.mockResolvedValueOnce(makePlatformRegistrationCredential())
+
+    const { result } = renderHook(() => useInvisibleWallet(CONFIG))
+
+    let registerResult!: Awaited<ReturnType<typeof result.current.register>>
+    await act(async () => { registerResult = await result.current.register('bob') })
+
+    expect(registerResult!.isPortableSigner).toBe(false)
+    expect(localStorage.getItem('invisible_wallet_portable_signer')).toBeNull()
+  })
+
+  it('exposes the portable signer via getPortableSigner()', async () => {
+    mockCredentialsCreate.mockResolvedValueOnce(makeRoamingRegistrationCredential())
+
+    const { result } = renderHook(() => useInvisibleWallet(CONFIG))
+    await act(async () => { await result.current.register('alice', { authenticatorAttachment: 'cross-platform' }) })
+
+    let signer!: Awaited<ReturnType<typeof result.current.getPortableSigner>>
+    await act(async () => { signer = await result.current.getPortableSigner() })
+
+    expect(signer).not.toBeNull()
+    expect(signer!.authenticatorAttachment).toBe('cross-platform')
+    expect(signer!.transports).toEqual(['usb', 'nfc'])
+  })
+
+  it('returns null from getPortableSigner() when only a platform passkey is registered', async () => {
+    mockCredentialsCreate.mockResolvedValueOnce(makePlatformRegistrationCredential())
+
+    const { result } = renderHook(() => useInvisibleWallet(CONFIG))
+    await act(async () => { await result.current.register('bob') })
+
+    let signer!: Awaited<ReturnType<typeof result.current.getPortableSigner>>
+    await act(async () => { signer = await result.current.getPortableSigner() })
+
+    expect(signer).toBeNull()
+  })
+
+  it('replays the roaming key transports when signing (e.g. from a second device)', async () => {
+    // Simulate a device that already holds the roaming credential in storage —
+    // the case of signing from a machine other than where the key was enrolled.
+    localStorage.setItem('invisible_wallet_key_id', 'cm9hbWluZy1rZXktaWQ')
+    localStorage.setItem('invisible_wallet_public_key', 'deadbeef')
+    localStorage.setItem('invisible_wallet_portable_signer', JSON.stringify({
+      credentialId: 'cm9hbWluZy1rZXktaWQ',
+      publicKey: 'deadbeef',
+      authenticatorAttachment: 'cross-platform',
+      transports: ['usb', 'nfc'],
+    }))
+
+    mockCredentialsGet.mockResolvedValueOnce(makeAssertionCredential())
+
+    const { result } = renderHook(() => useInvisibleWallet(CONFIG))
+    const payload = new Uint8Array(32).fill(9)
+
+    let sig!: Awaited<ReturnType<typeof result.current.signAuthEntry>>
+    await act(async () => { sig = await result.current.signAuthEntry(payload) })
+
+    expect(sig).not.toBeNull()
+    const opts = mockCredentialsGet.mock.calls[0][0].publicKey
+    expect(opts.allowCredentials[0].transports).toEqual(['usb', 'nfc'])
+  })
+})

--- a/sdk/src/useInvisibleWallet.ts
+++ b/sdk/src/useInvisibleWallet.ts
@@ -108,12 +108,54 @@ export type WebAuthnSignature = {
     signature: Uint8Array;
 };
 
+/**
+ * Where the WebAuthn credential lives.
+ *
+ * - `platform`       — a device-bound passkey (Touch ID, Windows Hello, …).
+ * - `cross-platform` — a roaming/portable FIDO2 security key (YubiKey, etc.)
+ *                      that can sign from any device it is plugged into.
+ */
+export type AuthenticatorAttachment = 'platform' | 'cross-platform';
+
+/** Optional knobs for register(). */
+export type RegisterOptions = {
+    /**
+     * Request a specific authenticator type. Pass `cross-platform` to enrol a
+     * roaming FIDO2 security key as a portable signer rather than a device-bound
+     * platform passkey. Defaults to letting the platform decide.
+     */
+    authenticatorAttachment?: AuthenticatorAttachment;
+};
+
+/**
+ * A roaming (cross-platform) credential, persisted independently of platform
+ * passkeys so it can be identified and used as a portable signer across devices.
+ */
+export type PortableSigner = {
+    /** Base64url-encoded credential ID of the roaming key. */
+    credentialId: string;
+    /** Hex-encoded uncompressed P-256 public key (65 bytes). */
+    publicKey: string;
+    /** Always `cross-platform` for a portable signer. */
+    authenticatorAttachment: 'cross-platform';
+    /** Transport hints (usb/nfc/ble/hybrid) used to prompt for the key. */
+    transports: string[];
+};
+
 /** Result returned by a successful register() call. */
 export type RegisterResult = {
     /** The deterministically computed contract address of the new wallet ("C..."). */
     walletAddress: string;
     /** The uncompressed P-256 public key bytes (65 bytes). */
     publicKeyBytes: Uint8Array;
+    /** The authenticator type the credential was created with, when reported. */
+    authenticatorAttachment?: AuthenticatorAttachment;
+    /**
+     * True when the credential is a roaming FIDO2 security key persisted as a
+     * portable signer (independent of platform passkeys). Optional so existing
+     * callers that don't enrol roaming keys remain source-compatible.
+     */
+    isPortableSigner?: boolean;
 };
 
 /** Result returned by a successful deploy() call. */
@@ -181,8 +223,15 @@ export type InvisibleWallet = {
     isDeployed: boolean;
     isPending: boolean;
     error: string | null;
-    /** Create a new passkey credential and compute the deterministic wallet address. */
-    register: (username?: string) => Promise<RegisterResult>;
+    /**
+     * Create a new WebAuthn credential and compute the deterministic wallet address.
+     *
+     * Pass `{ authenticatorAttachment: 'cross-platform' }` to enrol a roaming
+     * FIDO2 security key (YubiKey, etc.) as a portable signer that can sign from
+     * any device the key is plugged into. The roaming credential is persisted
+     * independently of platform passkeys — see {@link getPortableSigner}.
+     */
+    register: (username?: string, options?: RegisterOptions) => Promise<RegisterResult>;
     /**
      * Deploy the user's wallet contract on-chain via the factory.
      *
@@ -204,6 +253,12 @@ export type InvisibleWallet = {
      * @param signaturePayload  The 32-byte payload from the Soroban SorobanAuthorizationEntry.
      */
     signAuthEntry: (signaturePayload: Uint8Array) => Promise<WebAuthnSignature | null>;
+    /**
+     * Return the roaming FIDO2 credential persisted as a portable signer, or null
+     * if the active credential is a device-bound platform passkey. Stored under a
+     * dedicated key so it is identified independently of platform passkeys.
+     */
+    getPortableSigner: () => Promise<PortableSigner | null>;
     /**
      * Restore an existing wallet session from storage.
      * Verifies that the wallet contract actually exists on-chain before setting the address.
@@ -329,6 +384,9 @@ export type InvisibleWallet = {
 const POLL_INTERVAL_MS  = 1_000;
 const POLL_MAX_ATTEMPTS = 30;
 
+/** Storage key holding the roaming (cross-platform) credential as a portable signer. */
+const PORTABLE_SIGNER_KEY = 'invisible_wallet_portable_signer';
+
 /**
  * Poll server.getTransaction(hash) until the transaction leaves NOT_FOUND,
  * then return the final result. Throws if it fails or we exceed the attempt limit.
@@ -358,6 +416,21 @@ function resolveStorage(storage?: StorageAdapter): StorageAdapter {
         };
     }
     return { getItem: () => null, setItem: () => {}, removeItem: () => {} };
+}
+
+/** Read and parse the persisted portable-signer record, or null if none/invalid. */
+async function readPortableSigner(store: StorageAdapter): Promise<PortableSigner | null> {
+    const raw = await store.getItem(PORTABLE_SIGNER_KEY);
+    if (!raw) return null;
+    try {
+        const parsed = JSON.parse(raw) as PortableSigner;
+        if (parsed && parsed.authenticatorAttachment === 'cross-platform' && parsed.credentialId) {
+            return { ...parsed, transports: parsed.transports ?? [] };
+        }
+        return null;
+    } catch {
+        return null;
+    }
 }
 
 // ── Hook ──────────────────────────────────────────────────────────────────────
@@ -405,7 +478,7 @@ export function useInvisibleWallet(config: WalletConfig): InvisibleWallet {
 
     // ── register ──────────────────────────────────────────────────────────────
 
-    const register = useCallback(async (username?: string): Promise<RegisterResult> => {
+    const register = useCallback(async (username?: string, options?: RegisterOptions): Promise<RegisterResult> => {
         setIsPending(true);
         setError(null);
         try {
@@ -417,12 +490,13 @@ export function useInvisibleWallet(config: WalletConfig): InvisibleWallet {
 
             const resolvedRpId = rpId ?? (typeof window !== 'undefined' ? window.location.hostname : 'localhost');
 
-            const { credentialId, publicKeyBytes, attestationObject, clientDataJSON } = await webAuthnProvider.create({
+            const { credentialId, publicKeyBytes, attestationObject, clientDataJSON, authenticatorAttachment, transports } = await webAuthnProvider.create({
                 challenge,
                 rpId:     resolvedRpId,
                 rpName:   'Invisible Wallet',
                 userId,
                 userName: name,
+                authenticatorAttachment: options?.authenticatorAttachment,
             });
 
             // Optional attestation verification — enforce authenticator policy.
@@ -443,13 +517,35 @@ export function useInvisibleWallet(config: WalletConfig): InvisibleWallet {
             const publicKeyHex  = bufferToHex(publicKeyBytes);
             const walletAddress = computeWalletAddress(factoryAddress, publicKeyBytes, networkPassphrase);
 
+            // Treat the credential as a portable signer when either the caller asked
+            // for a roaming key or the platform reported a cross-platform attachment.
+            const resolvedAttachment = authenticatorAttachment ?? options?.authenticatorAttachment;
+            const isPortableSigner = resolvedAttachment === 'cross-platform';
+
             await store.setItem('invisible_wallet_address',    walletAddress);
             await store.setItem('invisible_wallet_key_id',     credentialId);
             await store.setItem('invisible_wallet_public_key', publicKeyHex);
+
+            if (isPortableSigner) {
+                // Persist the roaming credential under its own key so it is stored and
+                // identified independently of platform passkeys, and so signAuthEntry
+                // can replay its transports when signing from another device.
+                const portable: PortableSigner = {
+                    credentialId,
+                    publicKey: publicKeyHex,
+                    authenticatorAttachment: 'cross-platform',
+                    transports: transports ?? [],
+                };
+                await store.setItem(PORTABLE_SIGNER_KEY, JSON.stringify(portable));
+            } else if (store.removeItem) {
+                // Clear any stale portable-signer record from a previous roaming enrolment.
+                await store.removeItem(PORTABLE_SIGNER_KEY);
+            }
+
             setAddress(walletAddress);
             setIsDeployed(false);
 
-            return { walletAddress, publicKeyBytes };
+            return { walletAddress, publicKeyBytes, authenticatorAttachment: resolvedAttachment, isPortableSigner };
 
         } catch (err: unknown) {
             const message = err instanceof Error ? err.message : String(err);
@@ -459,6 +555,12 @@ export function useInvisibleWallet(config: WalletConfig): InvisibleWallet {
             setIsPending(false);
         }
     }, [factoryAddress, networkPassphrase, rpId, store, config.attestationPolicy, config.requireAttestation]);
+
+    // ── getPortableSigner ───────────────────────────────────────────────────────
+
+    const getPortableSigner = useCallback(async (): Promise<PortableSigner | null> => {
+        return readPortableSigner(store);
+    }, [store]);
 
     // ── deploy ────────────────────────────────────────────────────────────────
 
@@ -623,10 +725,15 @@ export function useInvisibleWallet(config: WalletConfig): InvisibleWallet {
                 signaturePayload.byteOffset + signaturePayload.byteLength
             ) as ArrayBuffer;
 
+            // For a roaming key, forward the stored transports so the assertion can
+            // prompt for the security key over USB/NFC/BLE on any device.
+            const portable = await readPortableSigner(store);
+
             const { authData, clientDataJSON, signature } = await webAuthnProvider.authenticate({
                 challenge,
                 credentialId: keyId,
                 rpId,
+                transports: portable?.transports,
             });
 
             const publicKeyBytes = hexToUint8Array(publicKeyHex);
@@ -1465,6 +1572,6 @@ export function useInvisibleWallet(config: WalletConfig): InvisibleWallet {
     }, [address, rpcUrl, networkPassphrase, signAuthEntry]);
 
     return useMemo(() => (
-        { address, isDeployed, isPending, error, register, deploy, signAuthEntry, login, getNonce, addSigner, removeSigner, getSigners, setGuardian, initiateRecovery, completeRecovery, approve, getAllowance, getBalance, sendPayment, outbox, replayOutbox }
-    ), [address, isDeployed, isPending, error, register, deploy, signAuthEntry, login, getNonce, addSigner, removeSigner, getSigners, setGuardian, initiateRecovery, completeRecovery, approve, getAllowance, getBalance, sendPayment, outbox, replayOutbox]);
+        { address, isDeployed, isPending, error, register, deploy, signAuthEntry, getPortableSigner, login, getNonce, addSigner, removeSigner, getSigners, setGuardian, initiateRecovery, completeRecovery, approve, getAllowance, getBalance, sendPayment, outbox, replayOutbox }
+    ), [address, isDeployed, isPending, error, register, deploy, signAuthEntry, getPortableSigner, login, getNonce, addSigner, removeSigner, getSigners, setGuardian, initiateRecovery, completeRecovery, approve, getAllowance, getBalance, sendPayment, outbox, replayOutbox]);
 }

--- a/sdk/src/webauthn.native.ts
+++ b/sdk/src/webauthn.native.ts
@@ -61,7 +61,9 @@ function spkiToP256Uncompressed(spki: Uint8Array): Uint8Array {
 // ── React Native provider ─────────────────────────────────────────────────────
 
 export const webAuthnProvider: WebAuthnProvider = {
-    async create({ challenge, rpId, rpName, userId, userName }): Promise<WebAuthnCreateResult> {
+    async create({ challenge, rpId, rpName, userId, userName, authenticatorAttachment }): Promise<WebAuthnCreateResult> {
+        const roaming = authenticatorAttachment === 'cross-platform';
+
         const result = await Passkey.create({
             challenge: uint8ArrayToB64url(challenge),
             rp:   { id: rpId, name: rpName },
@@ -73,8 +75,9 @@ export const webAuthnProvider: WebAuthnProvider = {
             pubKeyCredParams: [{ type: 'public-key', alg: -7 }],
             timeout: 60_000,
             authenticatorSelection: {
-                residentKey:      'preferred',
+                residentKey:      roaming ? 'required' : 'preferred',
                 userVerification: 'required',
+                ...(authenticatorAttachment ? { authenticatorAttachment } : {}),
             },
         });
 
@@ -96,20 +99,29 @@ export const webAuthnProvider: WebAuthnProvider = {
         const rawAttestation: string | undefined = result.response.attestationObject;
         const rawClientData:  string | undefined = result.response.clientDataJSON;
 
+        const reportedAttachment = result.authenticatorAttachment ?? authenticatorAttachment;
+        const transports: string[] | undefined = result.response.transports;
+
         return {
             credentialId: result.id,
             publicKeyBytes,
             attestationObject: rawAttestation ? b64urlToUint8Array(rawAttestation) : undefined,
             clientDataJSON:    rawClientData  ? b64urlToUint8Array(rawClientData)  : undefined,
+            authenticatorAttachment: reportedAttachment ?? undefined,
+            transports: transports && transports.length ? transports : undefined,
         };
     },
 
-    async authenticate({ challenge, credentialId, rpId }): Promise<WebAuthnAssertResult> {
+    async authenticate({ challenge, credentialId, rpId, transports }): Promise<WebAuthnAssertResult> {
         const challengeArr = new Uint8Array(challenge);
 
         const result = await Passkey.authenticate({
             challenge:         uint8ArrayToB64url(challengeArr),
-            allowCredentials:  [{ id: credentialId, type: 'public-key' }],
+            allowCredentials:  [{
+                id: credentialId,
+                type: 'public-key',
+                ...(transports && transports.length ? { transports } : {}),
+            }],
             userVerification:  'required',
             ...(rpId ? { rpId } : {}),
         });

--- a/sdk/src/webauthn.ts
+++ b/sdk/src/webauthn.ts
@@ -9,6 +9,15 @@ import { extractP256PublicKey, derToRawSignature } from './utils';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
+/**
+ * Where the authenticator lives.
+ *
+ * - `platform`       — bound to this device (Touch ID, Windows Hello, a phone passkey).
+ * - `cross-platform` — a roaming/portable authenticator such as a YubiKey or other
+ *                      FIDO2 security key that can move between machines.
+ */
+export type AuthenticatorAttachment = 'platform' | 'cross-platform';
+
 export interface WebAuthnCreateResult {
     /** Base64url-encoded credential ID. */
     credentialId: string;
@@ -22,6 +31,18 @@ export interface WebAuthnCreateResult {
     attestationObject?: Uint8Array;
     /** Raw clientDataJSON bytes from the registration response, when available. */
     clientDataJSON?: Uint8Array;
+    /**
+     * Which kind of authenticator produced the credential, as reported by the
+     * platform. Used to distinguish a roaming security key (`cross-platform`)
+     * from a device-bound platform passkey.
+     */
+    authenticatorAttachment?: AuthenticatorAttachment;
+    /**
+     * Transport hints (`usb`, `nfc`, `ble`, `hybrid`, `internal`) describing how
+     * the authenticator can be reached. Persisted with a roaming credential so a
+     * later assertion on any device can prompt for the right transport.
+     */
+    transports?: string[];
 }
 
 export interface WebAuthnAssertResult {
@@ -40,19 +61,31 @@ export interface WebAuthnProvider {
         rpName: string;
         userId: Uint8Array;
         userName: string;
+        /**
+         * Request a specific authenticator type. Pass `cross-platform` to require
+         * a roaming FIDO2 security key (YubiKey, etc.). Omitted lets the platform
+         * decide (typically a device-bound platform passkey).
+         */
+        authenticatorAttachment?: AuthenticatorAttachment;
     }): Promise<WebAuthnCreateResult>;
 
     authenticate(options: {
         challenge: ArrayBuffer;
         credentialId: string;
         rpId?: string;
+        /**
+         * Transport hints persisted with the credential. Forwarded to
+         * `allowCredentials` so a roaming key prompts over the correct transport
+         * (USB/NFC/BLE) on whatever device the assertion runs on.
+         */
+        transports?: string[];
     }): Promise<WebAuthnAssertResult>;
 }
 
 // ── Browser implementation ────────────────────────────────────────────────────
 
 export const webAuthnProvider: WebAuthnProvider = {
-    async create({ challenge, rpId, rpName, userId, userName }) {
+    async create({ challenge, rpId, rpName, userId, userName, authenticatorAttachment }) {
         // Slice to ensure a plain ArrayBuffer (Uint8Array.buffer may be SharedArrayBuffer)
         const challengeBuf = challenge.buffer.slice(
             challenge.byteOffset, challenge.byteOffset + challenge.byteLength
@@ -60,6 +93,10 @@ export const webAuthnProvider: WebAuthnProvider = {
         const userIdBuf = userId.buffer.slice(
             userId.byteOffset, userId.byteOffset + userId.byteLength
         ) as ArrayBuffer;
+
+        // A roaming key is portable, so a discoverable (resident) credential is
+        // what makes it usable from a second device without re-enrolling.
+        const roaming = authenticatorAttachment === 'cross-platform';
 
         const credential = await navigator.credentials.create({
             publicKey: {
@@ -69,8 +106,9 @@ export const webAuthnProvider: WebAuthnProvider = {
                 pubKeyCredParams: [{ type: 'public-key', alg: -7 }],
                 timeout: 60_000,
                 authenticatorSelection: {
-                    residentKey: 'preferred',
+                    residentKey: roaming ? 'required' : 'preferred',
                     userVerification: 'required',
+                    ...(authenticatorAttachment ? { authenticatorAttachment } : {}),
                 },
             },
         }) as PublicKeyCredential;
@@ -80,22 +118,35 @@ export const webAuthnProvider: WebAuthnProvider = {
         const response = credential.response as AuthenticatorAttestationResponse;
         const publicKeyBytes = await extractP256PublicKey(response);
 
+        // The platform reports the attachment actually used; fall back to what was
+        // requested so a roaming credential is still tagged when unreported.
+        const reportedAttachment =
+            (credential.authenticatorAttachment as AuthenticatorAttachment | null) ?? authenticatorAttachment;
+        const transports =
+            typeof response.getTransports === 'function' ? response.getTransports() : undefined;
+
         return {
             credentialId: credential.id,
             publicKeyBytes,
             attestationObject: new Uint8Array(response.attestationObject),
             clientDataJSON:    new Uint8Array(response.clientDataJSON),
+            authenticatorAttachment: reportedAttachment ?? undefined,
+            transports: transports && transports.length ? transports : undefined,
         };
     },
 
-    async authenticate({ challenge, credentialId, rpId }) {
+    async authenticate({ challenge, credentialId, rpId, transports }) {
         const credIdBin = atob(credentialId.replace(/-/g, '+').replace(/_/g, '/'));
         const credId = Uint8Array.from(credIdBin, c => c.charCodeAt(0));
 
         const assertion = await navigator.credentials.get({
             publicKey: {
                 challenge,
-                allowCredentials: [{ id: credId, type: 'public-key' }],
+                allowCredentials: [{
+                    id: credId,
+                    type: 'public-key',
+                    ...(transports && transports.length ? { transports: transports as AuthenticatorTransport[] } : {}),
+                }],
                 userVerification: 'required',
                 ...(rpId ? { rpId } : {}),
             },


### PR DESCRIPTION


closes #316

Platform passkeys are bound to a single device. This adds support for roaming
FIDO2 keys (YubiKey and other cross-platform authenticators) as portable signers
that work across machines.

### What changed
- WebAuthn registration now accepts `authenticatorAttachment`. Passing
  `'cross-platform'` requests a roaming security key and forces a discoverable
  (resident) credential — `residentKey: 'required'` — which is what makes the key
  usable from a second device without re-enrolling. Platform passkeys keep their
  existing `residentKey: 'preferred'` behaviour.
- The registration result now reports the authenticator attachment actually used
  and the credential's transports (`usb`/`nfc`/`ble`/`hybrid`), captured from
  `getTransports()` when the platform exposes them.
- A roaming credential is persisted under a dedicated storage key
  (`invisible_wallet_portable_signer`), so it is stored and identified
  independently of platform passkeys. A new `getPortableSigner()` method returns
  that record, or `null` when only a platform passkey is registered.
- `signAuthEntry()` replays the stored transports into `allowCredentials`, so an
  assertion prompts for the security key over the correct transport on whatever
  device runs it — enabling signing from a second machine that has the key
  plugged in.
- `register()` gains an optional `options` argument (`{ authenticatorAttachment }`).
  The React Native provider mirrors the same option plumbing.

### Acceptance criteria
- Register a roaming key and sign from a second device — roaming keys are enrolled
  as discoverable credentials and assertions forward transports, so the same
  physical key signs on any device.
- Credential stored/identified independently of platform passkeys — persisted
  under a separate key and surfaced via `getPortableSigner()`.
- Tests for cross-platform attachment options — added
  `sdk/src/__tests__/roaming-fido2.test.ts` covering attachment/transport plumbing
  and portable-signer persistence, identification, and signing.

### Compatibility
New `RegisterResult` fields are optional and `register()`'s new argument is
optional, so existing callers and the vanilla `InvisibleWallet` class are
unaffected. Public export surface is unchanged (only new types added).
