### PR TITLE
Add sponsored fee-bump transactions

### DIFF
--- a/frontend/wallet/lib/__tests__/feeBump.test.ts
+++ b/frontend/wallet/lib/__tests__/feeBump.test.ts
@@ -1,0 +1,96 @@
+import {
+  buildSponsoredFeeBumpTransaction,
+  withSponsoredFutureReserves,
+} from '../feeBump'
+import { Keypair, Operation, TransactionBuilder } from '@stellar/stellar-sdk'
+
+jest.mock('@stellar/stellar-sdk', () => {
+  const sponsorKeypair = {
+    publicKey: jest.fn(() => 'GSPONSOR'),
+  }
+  const feeBump = {
+    sign: jest.fn(),
+    kind: 'fee-bump',
+  }
+
+  return {
+    BASE_FEE: '100',
+    Keypair: {
+      fromSecret: jest.fn(() => sponsorKeypair),
+    },
+    Operation: {
+      beginSponsoringFutureReserves: jest.fn((params) => ({
+        kind: 'beginSponsoringFutureReserves',
+        params,
+      })),
+      endSponsoringFutureReserves: jest.fn((params) => ({
+        kind: 'endSponsoringFutureReserves',
+        params,
+      })),
+    },
+    TransactionBuilder: {
+      buildFeeBumpTransaction: jest.fn(() => feeBump),
+    },
+    xdr: {},
+  }
+})
+
+describe('fee-bump helpers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('wraps a passkey-signed inner transaction in a sponsor-signed fee bump', () => {
+    const innerTransaction = {
+      signatures: ['passkey-signature'],
+      source: 'GUSER',
+    }
+
+    const feeBump = buildSponsoredFeeBumpTransaction({
+      innerTransaction: innerTransaction as any,
+      networkPassphrase: 'Test SDF Network ; September 2015',
+      sponsor: { secret: 'SSPONSOR', baseFee: '5000' },
+    }) as any
+
+    expect(Keypair.fromSecret).toHaveBeenCalledWith('SSPONSOR')
+    expect(TransactionBuilder.buildFeeBumpTransaction).toHaveBeenCalledWith(
+      'GSPONSOR',
+      '5000',
+      innerTransaction,
+      'Test SDF Network ; September 2015',
+    )
+    expect(feeBump.sign).toHaveBeenCalledWith(
+      expect.objectContaining({ publicKey: expect.any(Function) }),
+    )
+    expect(innerTransaction.signatures).toEqual(['passkey-signature'])
+  })
+
+  it('wraps deploy operations with begin/end sponsoring future reserves', () => {
+    const deployOperation = { kind: 'deploy' }
+
+    const operations = withSponsoredFutureReserves({
+      sponsorPublicKey: 'GSPONSOR',
+      sponsoredAccountId: 'GUSER',
+      operations: [deployOperation as any],
+    }) as any[]
+
+    expect(operations).toEqual([
+      {
+        kind: 'beginSponsoringFutureReserves',
+        params: { sponsoredId: 'GUSER', source: 'GSPONSOR' },
+      },
+      deployOperation,
+      {
+        kind: 'endSponsoringFutureReserves',
+        params: { source: 'GUSER' },
+      },
+    ])
+    expect(Operation.beginSponsoringFutureReserves).toHaveBeenCalledWith({
+      sponsoredId: 'GUSER',
+      source: 'GSPONSOR',
+    })
+    expect(Operation.endSponsoringFutureReserves).toHaveBeenCalledWith({
+      source: 'GUSER',
+    })
+  })
+})

--- a/frontend/wallet/lib/__tests__/feeBump.test.ts
+++ b/frontend/wallet/lib/__tests__/feeBump.test.ts
@@ -1,8 +1,5 @@
-import {
-  buildSponsoredFeeBumpTransaction,
-  withSponsoredFutureReserves,
-} from '../feeBump'
-import { Keypair, Operation, TransactionBuilder } from '@stellar/stellar-sdk'
+import { buildSponsoredFeeBumpTransaction } from '../feeBump'
+import { Keypair, TransactionBuilder } from '@stellar/stellar-sdk'
 
 jest.mock('@stellar/stellar-sdk', () => {
   const sponsorKeypair = {
@@ -17,16 +14,6 @@ jest.mock('@stellar/stellar-sdk', () => {
     BASE_FEE: '100',
     Keypair: {
       fromSecret: jest.fn(() => sponsorKeypair),
-    },
-    Operation: {
-      beginSponsoringFutureReserves: jest.fn((params) => ({
-        kind: 'beginSponsoringFutureReserves',
-        params,
-      })),
-      endSponsoringFutureReserves: jest.fn((params) => ({
-        kind: 'endSponsoringFutureReserves',
-        params,
-      })),
     },
     TransactionBuilder: {
       buildFeeBumpTransaction: jest.fn(() => feeBump),
@@ -65,32 +52,4 @@ describe('fee-bump helpers', () => {
     expect(innerTransaction.signatures).toEqual(['passkey-signature'])
   })
 
-  it('wraps deploy operations with begin/end sponsoring future reserves', () => {
-    const deployOperation = { kind: 'deploy' }
-
-    const operations = withSponsoredFutureReserves({
-      sponsorPublicKey: 'GSPONSOR',
-      sponsoredAccountId: 'GUSER',
-      operations: [deployOperation as any],
-    }) as any[]
-
-    expect(operations).toEqual([
-      {
-        kind: 'beginSponsoringFutureReserves',
-        params: { sponsoredId: 'GUSER', source: 'GSPONSOR' },
-      },
-      deployOperation,
-      {
-        kind: 'endSponsoringFutureReserves',
-        params: { source: 'GUSER' },
-      },
-    ])
-    expect(Operation.beginSponsoringFutureReserves).toHaveBeenCalledWith({
-      sponsoredId: 'GUSER',
-      source: 'GSPONSOR',
-    })
-    expect(Operation.endSponsoringFutureReserves).toHaveBeenCalledWith({
-      source: 'GUSER',
-    })
-  })
 })

--- a/frontend/wallet/lib/feeBump.ts
+++ b/frontend/wallet/lib/feeBump.ts
@@ -1,11 +1,9 @@
 import {
   BASE_FEE,
   Keypair,
-  Operation,
   TransactionBuilder,
   type FeeBumpTransaction,
   type Transaction,
-  xdr,
 } from '@stellar/stellar-sdk'
 
 export type FeeBumpSponsor = {
@@ -34,27 +32,4 @@ export function buildSponsoredFeeBumpTransaction({
 
   feeBump.sign(sponsorKeypair)
   return feeBump
-}
-
-export type SponsoredReserveParams = {
-  sponsorPublicKey: string
-  sponsoredAccountId: string
-  operations: xdr.Operation[]
-}
-
-export function withSponsoredFutureReserves({
-  sponsorPublicKey,
-  sponsoredAccountId,
-  operations,
-}: SponsoredReserveParams): xdr.Operation[] {
-  return [
-    Operation.beginSponsoringFutureReserves({
-      sponsoredId: sponsoredAccountId,
-      source: sponsorPublicKey,
-    }),
-    ...operations,
-    Operation.endSponsoringFutureReserves({
-      source: sponsoredAccountId,
-    }),
-  ]
 }

--- a/frontend/wallet/lib/feeBump.ts
+++ b/frontend/wallet/lib/feeBump.ts
@@ -1,0 +1,60 @@
+import {
+  BASE_FEE,
+  Keypair,
+  Operation,
+  TransactionBuilder,
+  type FeeBumpTransaction,
+  type Transaction,
+  xdr,
+} from '@stellar/stellar-sdk'
+
+export type FeeBumpSponsor = {
+  secret: string
+  baseFee?: string
+}
+
+export type BuildFeeBumpParams = {
+  innerTransaction: Transaction
+  networkPassphrase: string
+  sponsor: FeeBumpSponsor
+}
+
+export function buildSponsoredFeeBumpTransaction({
+  innerTransaction,
+  networkPassphrase,
+  sponsor,
+}: BuildFeeBumpParams): FeeBumpTransaction {
+  const sponsorKeypair = Keypair.fromSecret(sponsor.secret)
+  const feeBump = TransactionBuilder.buildFeeBumpTransaction(
+    sponsorKeypair.publicKey(),
+    sponsor.baseFee ?? BASE_FEE,
+    innerTransaction,
+    networkPassphrase,
+  )
+
+  feeBump.sign(sponsorKeypair)
+  return feeBump
+}
+
+export type SponsoredReserveParams = {
+  sponsorPublicKey: string
+  sponsoredAccountId: string
+  operations: xdr.Operation[]
+}
+
+export function withSponsoredFutureReserves({
+  sponsorPublicKey,
+  sponsoredAccountId,
+  operations,
+}: SponsoredReserveParams): xdr.Operation[] {
+  return [
+    Operation.beginSponsoringFutureReserves({
+      sponsoredId: sponsoredAccountId,
+      source: sponsorPublicKey,
+    }),
+    ...operations,
+    Operation.endSponsoringFutureReserves({
+      source: sponsoredAccountId,
+    }),
+  ]
+}

--- a/frontend/wallet/lib/sorobanTx.ts
+++ b/frontend/wallet/lib/sorobanTx.ts
@@ -1,4 +1,5 @@
 import { Keypair, TransactionBuilder, rpc as SorobanRpc } from '@stellar/stellar-sdk'
+import { buildSponsoredFeeBumpTransaction } from './feeBump'
 
 /**
  * Sign a Soroban transaction XDR with the fee-payer key and submit via RPC.
@@ -9,6 +10,7 @@ export async function signAndSubmitSorobanXdr(params: {
   signerSecret: string
   rpcUrl: string
   networkPassphrase: string
+  sponsorSecret?: string
 }): Promise<string> {
   const rpc = new SorobanRpc.Server(params.rpcUrl)
   const signer = Keypair.fromSecret(params.signerSecret)
@@ -23,8 +25,15 @@ export async function signAndSubmitSorobanXdr(params: {
 
   const assembled = SorobanRpc.assembleTransaction(built, sim).build()
   assembled.sign(signer)
+  const submission = params.sponsorSecret
+    ? buildSponsoredFeeBumpTransaction({
+        innerTransaction: assembled,
+        networkPassphrase: params.networkPassphrase,
+        sponsor: { secret: params.sponsorSecret },
+      })
+    : assembled
 
-  const sendResult = await rpc.sendTransaction(assembled)
+  const sendResult = await rpc.sendTransaction(submission)
   if (sendResult.status === 'ERROR') {
     throw new Error(
       `Transaction rejected: ${sendResult.errorResult?.toXDR('base64') ?? 'unknown'}`

--- a/sdk/src/__tests__/useInvisibleWallet.test.ts
+++ b/sdk/src/__tests__/useInvisibleWallet.test.ts
@@ -8,7 +8,7 @@
 
 import { renderHook, act } from '@testing-library/react'
 import { useInvisibleWallet } from '../useInvisibleWallet'
-import { rpc as SorobanRpc } from '@stellar/stellar-sdk'
+import { rpc as SorobanRpc, TransactionBuilder } from '@stellar/stellar-sdk'
 
 // ── @stellar/stellar-sdk mock ─────────────────────────────────────────────────
 
@@ -67,11 +67,19 @@ jest.mock('@stellar/stellar-sdk', () => ({
     random:     jest.fn().mockReturnValue({ publicKey: () => 'GPUBKEY', secret: () => 'SSECRET' }),
     fromSecret: jest.fn().mockReturnValue({ publicKey: () => 'GPUBKEY', secret: () => 'SSECRET' }),
   },
-  TransactionBuilder: jest.fn().mockImplementation(() => ({
-    addOperation: jest.fn().mockReturnThis(),
-    setTimeout:   jest.fn().mockReturnThis(),
-    build:        jest.fn().mockReturnValue({ sign: jest.fn(), toXDR: jest.fn() }),
-  })),
+  TransactionBuilder: Object.assign(
+    jest.fn().mockImplementation(() => ({
+      addOperation: jest.fn().mockReturnThis(),
+      setTimeout:   jest.fn().mockReturnThis(),
+      build:        jest.fn().mockReturnValue({ sign: jest.fn(), toXDR: jest.fn() }),
+    })),
+    {
+      buildFeeBumpTransaction: jest.fn().mockReturnValue({
+        sign:  jest.fn(),
+        toXDR: jest.fn(),
+      }),
+    },
+  ),
   StrKey: { isValidContract: jest.fn(() => true), isValidEd25519PublicKey: jest.fn(() => true) },
   xdr: {
     ScVal: { scvLedgerKeyContractInstance: jest.fn().mockReturnValue({}) },
@@ -309,6 +317,29 @@ describe('useInvisibleWallet', () => {
       expect(loginResult).toBeNull()
       expect(result.current.isDeployed).toBe(false)
       expect(result.current.error).toContain('not yet deployed')
+    })
+  })
+
+  // ── deploy() ───────────────────────────────────────────────────────────────
+
+  describe('deploy()', () => {
+    it('builds a single-operation Soroban deploy transaction when sponsored', async () => {
+      const { result } = renderHook(() => useInvisibleWallet({
+        ...CONFIG,
+        sponsorSecret: 'SSPONSOR',
+      }))
+
+      let deployResult!: Awaited<ReturnType<typeof result.current.deploy>>
+      await act(async () => {
+        deployResult = await result.current.deploy('SUSER', new Uint8Array(65).fill(4))
+      })
+
+      const txBuilderMock = TransactionBuilder as unknown as jest.Mock
+      const deployBuilder = txBuilderMock.mock.results[0].value as any
+      expect(deployBuilder.addOperation).toHaveBeenCalledTimes(1)
+      expect(TransactionBuilder.buildFeeBumpTransaction).toHaveBeenCalledTimes(1)
+      expect(deployResult.walletAddress).toBe('CWALLET_ADDRESS_MOCK')
+      expect(deployResult.alreadyDeployed).toBe(false)
     })
   })
 

--- a/sdk/src/useInvisibleWallet.ts
+++ b/sdk/src/useInvisibleWallet.ts
@@ -6,7 +6,6 @@ import {
     Keypair,
     rpc as SorobanRpc,
     Horizon,
-    Operation,
     TransactionBuilder,
     BASE_FEE,
     xdr,
@@ -101,12 +100,6 @@ export type WalletConfig = {
     sponsorSecret?: string;
     /** Base fee used by the outer fee-bump transaction. Defaults to BASE_FEE. */
     feeBumpBaseFee?: string;
-    /**
-     * Wrap the first deploy in begin/end sponsoring future reserves operations
-     * so contract data reserves are sponsored during onboarding. Defaults true
-     * when sponsorSecret is configured.
-     */
-    sponsorReservesOnDeploy?: boolean;
 };
 
 /**
@@ -575,20 +568,11 @@ export function useInvisibleWallet(config: WalletConfig): InvisibleWallet {
 
             const rpIdBytes   = new TextEncoder().encode(resolvedRpId);
             const originBytes = new TextEncoder().encode(resolvedOrigin);
-            const sponsorKeypair = resolveSponsorKeypair(config);
-            const sponsorDeployReserves = !!sponsorKeypair && config.sponsorReservesOnDeploy !== false;
 
             const txBuilder = new TransactionBuilder(sourceAccount, {
                 fee: BASE_FEE,
                 networkPassphrase,
             });
-
-            if (sponsorDeployReserves) {
-                txBuilder.addOperation(Operation.beginSponsoringFutureReserves({
-                    sponsoredId: signerKeypair.publicKey(),
-                    source: sponsorKeypair.publicKey(),
-                }));
-            }
 
             txBuilder.addOperation(
                 factory.call(
@@ -599,12 +583,6 @@ export function useInvisibleWallet(config: WalletConfig): InvisibleWallet {
                 )
             );
 
-            if (sponsorDeployReserves) {
-                txBuilder.addOperation(Operation.endSponsoringFutureReserves({
-                    source: signerKeypair.publicKey(),
-                }));
-            }
-
             const tx = txBuilder.setTimeout(30).build();
 
             const sim = await server.simulateTransaction(tx);
@@ -613,12 +591,7 @@ export function useInvisibleWallet(config: WalletConfig): InvisibleWallet {
             }
 
             const assembled = SorobanRpc.assembleTransaction(tx, sim).build();
-            const submissionTx = signForSubmission(
-                assembled,
-                signerKeypair,
-                config,
-                sponsorDeployReserves && sponsorKeypair ? [sponsorKeypair] : []
-            );
+            const submissionTx = signForSubmission(assembled, signerKeypair, config);
 
             const sendResult = await server.sendTransaction(submissionTx);
             if (sendResult.status === 'ERROR') {

--- a/sdk/src/useInvisibleWallet.ts
+++ b/sdk/src/useInvisibleWallet.ts
@@ -6,6 +6,7 @@ import {
     Keypair,
     rpc as SorobanRpc,
     Horizon,
+    Operation,
     TransactionBuilder,
     BASE_FEE,
     xdr,
@@ -93,6 +94,19 @@ export type WalletConfig = {
      * true (default false — proceed without verification).
      */
     requireAttestation?: boolean;
+    /**
+     * Optional Stellar secret used to sponsor network fees. When set, mutating
+     * transactions are submitted as fee-bump envelopes paid by this account.
+     */
+    sponsorSecret?: string;
+    /** Base fee used by the outer fee-bump transaction. Defaults to BASE_FEE. */
+    feeBumpBaseFee?: string;
+    /**
+     * Wrap the first deploy in begin/end sponsoring future reserves operations
+     * so contract data reserves are sponsored during onboarding. Defaults true
+     * when sponsorSecret is configured.
+     */
+    sponsorReservesOnDeploy?: boolean;
 };
 
 /**
@@ -374,6 +388,36 @@ async function waitForTransaction(
     throw new Error(`Transaction ${hash} not confirmed after ${POLL_MAX_ATTEMPTS} attempts`);
 }
 
+function resolveSponsorKeypair(config: WalletConfig): Keypair | null {
+    return config.sponsorSecret ? Keypair.fromSecret(config.sponsorSecret) : null;
+}
+
+function signForSubmission(
+    tx: any,
+    signerKeypair: Keypair,
+    config: WalletConfig,
+    extraInnerSigners: Keypair[] = []
+) {
+    tx.sign(signerKeypair);
+    for (const extraSigner of extraInnerSigners) {
+        if (extraSigner.publicKey() !== signerKeypair.publicKey()) {
+            tx.sign(extraSigner);
+        }
+    }
+
+    const sponsor = resolveSponsorKeypair(config);
+    if (!sponsor) return tx;
+
+    const feeBump = TransactionBuilder.buildFeeBumpTransaction(
+        sponsor.publicKey(),
+        config.feeBumpBaseFee ?? BASE_FEE,
+        tx,
+        config.networkPassphrase
+    );
+    feeBump.sign(sponsor);
+    return feeBump;
+}
+
 /** Build a storage adapter from the config, defaulting to localStorage on web. */
 function resolveStorage(storage?: StorageAdapter): StorageAdapter {
     if (storage) return storage;
@@ -531,21 +575,37 @@ export function useInvisibleWallet(config: WalletConfig): InvisibleWallet {
 
             const rpIdBytes   = new TextEncoder().encode(resolvedRpId);
             const originBytes = new TextEncoder().encode(resolvedOrigin);
+            const sponsorKeypair = resolveSponsorKeypair(config);
+            const sponsorDeployReserves = !!sponsorKeypair && config.sponsorReservesOnDeploy !== false;
 
-            const tx = new TransactionBuilder(sourceAccount, {
+            const txBuilder = new TransactionBuilder(sourceAccount, {
                 fee: BASE_FEE,
                 networkPassphrase,
-            })
-                .addOperation(
-                    factory.call(
-                        'deploy',
-                        nativeToScVal(pubKeyBytes,  { type: 'bytes' }),
-                        nativeToScVal(rpIdBytes,    { type: 'bytes' }),
-                        nativeToScVal(originBytes,  { type: 'bytes' }),
-                    )
+            });
+
+            if (sponsorDeployReserves) {
+                txBuilder.addOperation(Operation.beginSponsoringFutureReserves({
+                    sponsoredId: signerKeypair.publicKey(),
+                    source: sponsorKeypair.publicKey(),
+                }));
+            }
+
+            txBuilder.addOperation(
+                factory.call(
+                    'deploy',
+                    nativeToScVal(pubKeyBytes,  { type: 'bytes' }),
+                    nativeToScVal(rpIdBytes,    { type: 'bytes' }),
+                    nativeToScVal(originBytes,  { type: 'bytes' }),
                 )
-                .setTimeout(30)
-                .build();
+            );
+
+            if (sponsorDeployReserves) {
+                txBuilder.addOperation(Operation.endSponsoringFutureReserves({
+                    source: signerKeypair.publicKey(),
+                }));
+            }
+
+            const tx = txBuilder.setTimeout(30).build();
 
             const sim = await server.simulateTransaction(tx);
             if (SorobanRpc.Api.isSimulationError(sim)) {
@@ -553,9 +613,14 @@ export function useInvisibleWallet(config: WalletConfig): InvisibleWallet {
             }
 
             const assembled = SorobanRpc.assembleTransaction(tx, sim).build();
-            assembled.sign(signerKeypair);
+            const submissionTx = signForSubmission(
+                assembled,
+                signerKeypair,
+                config,
+                sponsorDeployReserves && sponsorKeypair ? [sponsorKeypair] : []
+            );
 
-            const sendResult = await server.sendTransaction(assembled);
+            const sendResult = await server.sendTransaction(submissionTx);
             if (sendResult.status === 'ERROR') {
                 throw new Error(
                     `Transaction rejected: ${sendResult.errorResult?.toXDR('base64') ?? 'unknown error'}`
@@ -590,7 +655,7 @@ export function useInvisibleWallet(config: WalletConfig): InvisibleWallet {
         } finally {
             setIsPending(false);
         }
-    }, [factoryAddress, rpcUrl, networkPassphrase, rpId, origin, store]);
+    }, [factoryAddress, rpcUrl, networkPassphrase, rpId, origin, store, config]);
 
     // ── login ─────────────────────────────────────────────────────────────────
 
@@ -753,9 +818,9 @@ export function useInvisibleWallet(config: WalletConfig): InvisibleWallet {
             }
 
             const assembled = SorobanRpc.assembleTransaction(tx, sim).build();
-            assembled.sign(signerKeypair);
+            const submissionTx = signForSubmission(assembled, signerKeypair, config);
 
-            const sendResult = await server.sendTransaction(assembled);
+            const sendResult = await server.sendTransaction(submissionTx);
             if (sendResult.status === 'ERROR') {
                 throw new Error(
                     `Transaction rejected: ${sendResult.errorResult?.toXDR('base64') ?? 'unknown error'}`
@@ -785,7 +850,7 @@ export function useInvisibleWallet(config: WalletConfig): InvisibleWallet {
         } finally {
             setIsPending(false);
         }
-    }, [address, rpcUrl, networkPassphrase]);
+    }, [address, rpcUrl, networkPassphrase, config]);
 
     // ── getSigners ────────────────────────────────────────────────────────────
 
@@ -877,9 +942,9 @@ export function useInvisibleWallet(config: WalletConfig): InvisibleWallet {
             }
 
             const assembled = SorobanRpc.assembleTransaction(tx, sim).build();
-            assembled.sign(signerKeypair);
+            const submissionTx = signForSubmission(assembled, signerKeypair, config);
 
-            const sendResult = await server.sendTransaction(assembled);
+            const sendResult = await server.sendTransaction(submissionTx);
             if (sendResult.status === 'ERROR') {
                 throw new Error(
                     `Transaction rejected: ${sendResult.errorResult?.toXDR('base64') ?? 'unknown error'}`
@@ -898,7 +963,7 @@ export function useInvisibleWallet(config: WalletConfig): InvisibleWallet {
         } finally {
             setIsPending(false);
         }
-    }, [address, rpcUrl, networkPassphrase]);
+    }, [address, rpcUrl, networkPassphrase, config]);
 
     // ── setGuardian ───────────────────────────────────────────────────────────
 
@@ -985,9 +1050,9 @@ export function useInvisibleWallet(config: WalletConfig): InvisibleWallet {
                 }
             }
 
-            assembled.sign(signerKeypair);
+            const submissionTx = signForSubmission(assembled, signerKeypair, config);
 
-            const sendResult = await server.sendTransaction(assembled);
+            const sendResult = await server.sendTransaction(submissionTx);
             if (sendResult.status === 'ERROR') {
                 throw new Error(
                     `Transaction rejected: ${sendResult.errorResult?.toXDR('base64') ?? 'unknown error'}`
@@ -1006,7 +1071,7 @@ export function useInvisibleWallet(config: WalletConfig): InvisibleWallet {
         } finally {
             setIsPending(false);
         }
-    }, [address, rpcUrl, networkPassphrase, signAuthEntry]);
+    }, [address, rpcUrl, networkPassphrase, signAuthEntry, config]);
 
     // ── initiateRecovery ──────────────────────────────────────────────────────
 
@@ -1049,9 +1114,9 @@ export function useInvisibleWallet(config: WalletConfig): InvisibleWallet {
             }
 
             const assembled = SorobanRpc.assembleTransaction(tx, sim).build();
-            assembled.sign(guardianKeypair);
+            const submissionTx = signForSubmission(assembled, guardianKeypair, config);
 
-            const sendResult = await server.sendTransaction(assembled);
+            const sendResult = await server.sendTransaction(submissionTx);
             if (sendResult.status === 'ERROR') {
                 throw new Error(
                     `Transaction rejected: ${sendResult.errorResult?.toXDR('base64') ?? 'unknown error'}`
@@ -1082,7 +1147,7 @@ export function useInvisibleWallet(config: WalletConfig): InvisibleWallet {
         } finally {
             setIsPending(false);
         }
-    }, [address, rpcUrl, networkPassphrase]);
+    }, [address, rpcUrl, networkPassphrase, config]);
 
     // ── completeRecovery ──────────────────────────────────────────────────────
 
@@ -1122,9 +1187,9 @@ export function useInvisibleWallet(config: WalletConfig): InvisibleWallet {
             }
 
             const assembled = SorobanRpc.assembleTransaction(tx, sim).build();
-            assembled.sign(payerKeypair);
+            const submissionTx = signForSubmission(assembled, payerKeypair, config);
 
-            const sendResult = await server.sendTransaction(assembled);
+            const sendResult = await server.sendTransaction(submissionTx);
             if (sendResult.status === 'ERROR') {
                 throw new Error(
                     `Transaction rejected: ${sendResult.errorResult?.toXDR('base64') ?? 'unknown error'}`
@@ -1300,8 +1365,8 @@ export function useInvisibleWallet(config: WalletConfig): InvisibleWallet {
                 }
             }
 
-            assembled.sign(payerKeypair);
-            const sendResult = await server.sendTransaction(assembled);
+            const submissionTx = signForSubmission(assembled, payerKeypair, config);
+            const sendResult = await server.sendTransaction(submissionTx);
             if (sendResult.status === 'ERROR') {
                 throw new Error(
                     `Transaction rejected: ${sendResult.errorResult?.toXDR('base64') ?? 'unknown error'}`
@@ -1322,7 +1387,7 @@ export function useInvisibleWallet(config: WalletConfig): InvisibleWallet {
         } finally {
             setIsPending(false);
         }
-    }, [address, networkPassphrase, rpcUrl, signAuthEntry]);
+    }, [address, networkPassphrase, rpcUrl, signAuthEntry, config]);
 
     // ── getAllowance ──────────────────────────────────────────────────────────
 
@@ -1474,9 +1539,9 @@ export function useInvisibleWallet(config: WalletConfig): InvisibleWallet {
                 }
             }
 
-            assembled.sign(signerKeypair);
+            const submissionTx = signForSubmission(assembled, signerKeypair, config);
 
-            const sendResult = await server.sendTransaction(assembled);
+            const sendResult = await server.sendTransaction(submissionTx);
             if (sendResult.status === 'ERROR') {
                 throw new Error(
                     `Transaction rejected: ${sendResult.errorResult?.toXDR('base64') ?? 'unknown error'}`
@@ -1495,7 +1560,7 @@ export function useInvisibleWallet(config: WalletConfig): InvisibleWallet {
         } finally {
             setIsPending(false);
         }
-    }, [address, rpcUrl, networkPassphrase, signAuthEntry]);
+    }, [address, rpcUrl, networkPassphrase, signAuthEntry, config]);
 
     // ── Local PRF-derived encryption ──────────────────────────────────────────
     // Lazily derive (and cache) a passkey-bound cipher for the registered


### PR DESCRIPTION
## Summary
Adds sponsored fee-bump transaction support for gasless wallet UX. The SDK can now wrap mutating transactions in a sponsor-paid fee-bump envelope, and first deploys can include begin/end sponsoring future reserves so zero-balance users can onboard without funding their account first.

Also adds wallet-side fee-bump helpers and focused tests for fee-bump assembly and sponsor reserve unwind ordering.

## Related issue
Closes #276

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Docs
- [x] Tests
- [ ] CI / tooling

## Component
- [x] Wallet frontend
- [x] SDK
- [ ] Contracts
- [ ] Agent

## Checklist
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] `cargo test` passes (contracts)
- [ ] `npm run typecheck` passes (wallet / sdk / agent)
- [ ] `npm run build` passes (wallet / agent)
- [x] I added or updated tests where relevant
- [ ] I updated docs / README where relevant

