### PR TITLE
feat(sdk,wallet): real-time wallet activity feed via SSE

### DIFF
--- a/frontend/wallet/app/dashboard/page.tsx
+++ b/frontend/wallet/app/dashboard/page.tsx
@@ -22,6 +22,7 @@ import { sweepContractBalance } from '@/lib/sweepContractBalance'
 import { derToRawSignature, hexToUint8Array } from '@veil/utils'
 import type { WebAuthnSignature } from '@veil/sdk'
 import { getDueSchedules, updateSchedule, advanceNextRun, type PaymentSchedule } from '@/lib/schedules'
+import { useActivityFeed, initActivityFeed, hydrateActivityFeed } from '@/lib/activityFeed'
 
 const network = getNetwork()
 
@@ -37,10 +38,9 @@ export interface WalletAsset {
 // Survives component unmount/remount within the SPA so navigating away and
 // back doesn't flash the skeleton state. Cleared on hard refresh (intentional).
 // Refetch still happens in the background to keep data fresh.
-let cachedAssets:       WalletAsset[]                 | null = null
-let cachedTransactions: TxRecord[]                    | null = null
-let cachedContractXlm:  number                        | null = null
-let cachedPrices:       Record<string, number | null>        = {}
+let cachedAssets:      WalletAsset[]                 | null = null
+let cachedContractXlm: number                        | null = null
+let cachedPrices:      Record<string, number | null>        = {}
 
 // ── Dashboard page ────────────────────────────────────────────────────────────
 function DashboardPageContent() {
@@ -50,7 +50,7 @@ function DashboardPageContent() {
 
   const [walletAddress, setWalletAddress] = useState<string | null>(null)
   const [assets, setAssets]               = useState<WalletAsset[]>(() => cachedAssets ?? [])
-  const [transactions, setTransactions]   = useState<TxRecord[]>(() => cachedTransactions ?? [])
+  const transactions                      = useActivityFeed()
   const [selectedTx, setSelectedTx]       = useState<TxRecord | null>(null)
   const [txFilter, setTxFilter]           = useState<'all' | 'transfers' | 'swaps'>('all')
   const [loading, setLoading]             = useState(cachedAssets === null)
@@ -83,8 +83,6 @@ function DashboardPageContent() {
 
   const fetchData = useCallback(async () => {
     if (!walletAddress) return   // keep loading=true until address is ready
-    // Only show skeleton if we have NO cached data — otherwise refetch silently
-    // in the background and update once the new data arrives.
     if (cachedAssets === null) setLoading(true)
 
     const horizonServer = new Server(network.horizonUrl)
@@ -279,10 +277,15 @@ function DashboardPageContent() {
       { code: 'XLM', issuer: null, balance: totalXlm },
       ...otherAssets,
     ]
-    cachedAssets       = finalAssets
-    cachedTransactions = txRecords
+    cachedAssets = finalAssets
     setAssets(finalAssets)
-    setTransactions(txRecords)
+
+    // Seed the live feed with history and start streaming from now.
+    // hydrateActivityFeed notifies all subscribers (including useActivityFeed),
+    // so no separate setTransactions call is needed.
+    hydrateActivityFeed(txRecords)
+    if (signerPublicKey) initActivityFeed(signerPublicKey)
+
     setLoading(false)
   }, [walletAddress])
 

--- a/frontend/wallet/lib/activityFeed.ts
+++ b/frontend/wallet/lib/activityFeed.ts
@@ -1,0 +1,85 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { createActivityFeed, type ActivityEvent, type ActivityFeed } from '@veil/events'
+import { getNetwork } from './network'
+import type { TxRecord } from '@/components/TxDetailSheet'
+
+export type { ActivityEvent }
+
+type ActivityListener = (records: TxRecord[]) => void
+
+let _records: TxRecord[] = []
+let _feed: ActivityFeed | null = null
+let _currentAccountId: string | null = null
+const _listeners = new Set<ActivityListener>()
+
+function notify(): void {
+  for (const listener of _listeners) listener([..._records])
+}
+
+function toTxRecord(event: ActivityEvent): TxRecord {
+  return {
+    id: event.id,
+    type:
+      event.type === 'payment_sent'
+        ? 'sent'
+        : event.type === 'path_payment'
+        ? 'swapped'
+        : 'received',
+    amount: event.amount,
+    asset: event.asset,
+    counterparty: event.counterparty,
+    timestamp: event.timestamp,
+    hash: event.hash,
+    memo: event.memo,
+    destAmount: event.destAmount,
+    destAsset: event.destAsset,
+  }
+}
+
+export function initActivityFeed(accountId: string): void {
+  if (_feed && _currentAccountId === accountId) return
+
+  _feed?.stop()
+  _currentAccountId = accountId
+
+  const { horizonUrl } = getNetwork()
+
+  _feed = createActivityFeed({
+    accountId,
+    horizonUrl,
+    onEvent(event) {
+      const record = toTxRecord(event)
+      if (_records.some(r => r.hash === record.hash)) return
+      _records = [record, ..._records].slice(0, 50)
+      notify()
+    },
+  })
+}
+
+export function stopActivityFeed(): void {
+  _feed?.stop()
+  _feed = null
+  _currentAccountId = null
+}
+
+export function hydrateActivityFeed(records: TxRecord[]): void {
+  _records = records
+  notify()
+}
+
+export function subscribeActivityFeed(listener: ActivityListener): () => void {
+  _listeners.add(listener)
+  listener([..._records])
+  return () => _listeners.delete(listener)
+}
+
+export function useActivityFeed(): TxRecord[] {
+  const [records, setRecords] = useState<TxRecord[]>(() => [..._records])
+
+  useEffect(() => subscribeActivityFeed(setRecords), [])
+
+  return records
+}
+

--- a/frontend/wallet/tsconfig.json
+++ b/frontend/wallet/tsconfig.json
@@ -17,6 +17,7 @@
     "paths": {
       "@/*": ["./*"],
       "@veil/sdk": ["../../sdk/src/useInvisibleWallet"],
+      "@veil/events": ["../../sdk/src/events"],
       "@veil/utils": ["../../sdk/src/utils"],
       "@veil/recovery": ["../../sdk/src/recovery/sep30"],
       "@veil/backup": ["../../sdk/src/backup"],

--- a/sdk/src/__tests__/events.test.ts
+++ b/sdk/src/__tests__/events.test.ts
@@ -1,0 +1,326 @@
+import { mapHorizonOpToEvent, createActivityFeed, type RawHorizonOp } from '../events'
+
+jest.mock('@stellar/stellar-sdk', () => ({
+  Horizon: {
+    Server: jest.fn(),
+  },
+}))
+
+const sdk = jest.requireMock('@stellar/stellar-sdk') as Record<string, any>
+const MockHorizonServer: jest.Mock = sdk.Horizon.Server
+
+function makeOp(overrides: Partial<RawHorizonOp> = {}): RawHorizonOp {
+  return {
+    id: '1',
+    paging_token: 'pt-1',
+    type: 'payment',
+    from: 'GAAA',
+    to: 'GBBB',
+    amount: '10.0000000',
+    asset_type: 'native',
+    created_at: '2024-01-01T00:00:00Z',
+    transaction_hash: 'abc123',
+    ...overrides,
+  }
+}
+
+const ACCOUNT_ID = 'GAAA'
+
+// ── mapHorizonOpToEvent ────────────────────────────────────────────────────────
+
+describe('mapHorizonOpToEvent', () => {
+  it('maps an incoming native payment to payment_received', () => {
+    const event = mapHorizonOpToEvent(makeOp({ from: 'GBBB', to: ACCOUNT_ID }), ACCOUNT_ID)
+    expect(event).not.toBeNull()
+    expect(event!.type).toBe('payment_received')
+    expect(event!.amount).toBe('10.0000000')
+    expect(event!.asset).toBe('XLM')
+    expect(event!.counterparty).toBe('GBBB')
+    expect(event!.hash).toBe('abc123')
+    expect(event!.id).toBe('pt-1')
+  })
+
+  it('maps an outgoing native payment to payment_sent', () => {
+    const event = mapHorizonOpToEvent(makeOp({ from: ACCOUNT_ID, to: 'GBBB' }), ACCOUNT_ID)
+    expect(event!.type).toBe('payment_sent')
+    expect(event!.counterparty).toBe('GBBB')
+  })
+
+  it('maps a non-native asset payment and sets the correct asset code', () => {
+    const event = mapHorizonOpToEvent(
+      makeOp({ from: 'GBBB', to: ACCOUNT_ID, asset_type: 'credit_alphanum4', asset_code: 'USDC' }),
+      ACCOUNT_ID,
+    )
+    expect(event!.asset).toBe('USDC')
+  })
+
+  it('includes memo from nested transaction object', () => {
+    const event = mapHorizonOpToEvent(
+      makeOp({ from: 'GBBB', to: ACCOUNT_ID, transaction: { memo: 'invoice-42' } }),
+      ACCOUNT_ID,
+    )
+    expect(event!.memo).toBe('invoice-42')
+  })
+
+  it('maps create_account to account_created', () => {
+    const event = mapHorizonOpToEvent(
+      makeOp({ type: 'create_account', funder: 'GFRIEND', starting_balance: '100.0000000' }),
+      ACCOUNT_ID,
+    )
+    expect(event!.type).toBe('account_created')
+    expect(event!.counterparty).toBe('GFRIEND')
+    expect(event!.amount).toBe('100.0000000')
+    expect(event!.asset).toBe('XLM')
+  })
+
+  it('defaults counterparty to "Friendbot" when funder is missing', () => {
+    const event = mapHorizonOpToEvent(
+      makeOp({ type: 'create_account', starting_balance: '1.0000000' }),
+      ACCOUNT_ID,
+    )
+    expect(event!.counterparty).toBe('Friendbot')
+  })
+
+  it('maps path_payment_strict_send to path_payment with source and dest fields', () => {
+    const event = mapHorizonOpToEvent(
+      makeOp({
+        type: 'path_payment_strict_send',
+        source_asset_type: 'native',
+        source_amount: '5.0000000',
+        asset_type: 'credit_alphanum4',
+        asset_code: 'USDC',
+        amount: '4.9000000',
+      }),
+      ACCOUNT_ID,
+    )
+    expect(event!.type).toBe('path_payment')
+    expect(event!.asset).toBe('XLM')
+    expect(event!.amount).toBe('5.0000000')
+    expect(event!.destAsset).toBe('USDC')
+    expect(event!.destAmount).toBe('4.9000000')
+    expect(event!.counterparty).toBe('Stellar DEX')
+  })
+
+  it('returns null for op types that are not tracked', () => {
+    expect(mapHorizonOpToEvent(makeOp({ type: 'manage_buy_offer' }), ACCOUNT_ID)).toBeNull()
+    expect(mapHorizonOpToEvent(makeOp({ type: 'set_options' }), ACCOUNT_ID)).toBeNull()
+    expect(mapHorizonOpToEvent(makeOp({ type: 'change_trust' }), ACCOUNT_ID)).toBeNull()
+  })
+
+  it('sets timestamp from created_at', () => {
+    const event = mapHorizonOpToEvent(
+      makeOp({ created_at: '2024-06-15T12:00:00Z' }),
+      ACCOUNT_ID,
+    )
+    expect(event!.timestamp).toBe(Math.floor(new Date('2024-06-15T12:00:00Z').getTime() / 1000))
+  })
+})
+
+// ── createActivityFeed ────────────────────────────────────────────────────────
+
+describe('createActivityFeed', () => {
+  let capturedCallbacks: { onmessage?: (op: any) => void; onerror?: () => void }
+  let capturedCursors: string[]
+  let mockStopStream: jest.Mock
+  let mockStreamFn: jest.Mock
+  let mockCursorFn: jest.Mock
+
+  beforeEach(() => {
+    jest.useFakeTimers()
+    jest.clearAllMocks()
+
+    capturedCallbacks = {}
+    capturedCursors = []
+    mockStopStream = jest.fn()
+
+    mockStreamFn = jest.fn().mockImplementation((cbs: any) => {
+      capturedCallbacks = cbs
+      return mockStopStream
+    })
+
+    mockCursorFn = jest.fn().mockImplementation((cursor: string) => {
+      capturedCursors.push(cursor)
+      return { stream: mockStreamFn }
+    })
+
+    MockHorizonServer.mockImplementation(() => ({
+      payments: jest.fn().mockReturnValue({
+        forAccount: jest.fn().mockReturnValue({
+          cursor: mockCursorFn,
+        }),
+      }),
+    }))
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('opens a stream immediately on creation with cursor "now"', () => {
+    const feed = createActivityFeed({
+      accountId: ACCOUNT_ID,
+      horizonUrl: 'https://horizon-testnet.stellar.org',
+      onEvent: jest.fn(),
+    })
+
+    expect(mockStreamFn).toHaveBeenCalledTimes(1)
+    expect(capturedCursors[0]).toBe('now')
+
+    feed.stop()
+  })
+
+  it('calls onEvent with mapped events from the stream', () => {
+    const onEvent = jest.fn()
+    const feed = createActivityFeed({
+      accountId: ACCOUNT_ID,
+      horizonUrl: 'https://horizon-testnet.stellar.org',
+      onEvent,
+    })
+
+    capturedCallbacks.onmessage!(makeOp({ from: 'GBBB', to: ACCOUNT_ID }))
+
+    expect(onEvent).toHaveBeenCalledTimes(1)
+    expect(onEvent.mock.calls[0][0].type).toBe('payment_received')
+
+    feed.stop()
+  })
+
+  it('does not call onEvent for untracked op types', () => {
+    const onEvent = jest.fn()
+    const feed = createActivityFeed({
+      accountId: ACCOUNT_ID,
+      horizonUrl: 'https://horizon-testnet.stellar.org',
+      onEvent,
+    })
+
+    capturedCallbacks.onmessage!(makeOp({ type: 'manage_buy_offer' }))
+
+    expect(onEvent).not.toHaveBeenCalled()
+
+    feed.stop()
+  })
+
+  it('calls onError and reconnects with the last seen cursor after a stream error', () => {
+    const onEvent = jest.fn()
+    const onError = jest.fn()
+    const feed = createActivityFeed({
+      accountId: ACCOUNT_ID,
+      horizonUrl: 'https://horizon-testnet.stellar.org',
+      onEvent,
+      onError,
+    })
+
+    // Advance the cursor by receiving an event
+    capturedCallbacks.onmessage!(makeOp({ paging_token: 'pt-42', from: 'GBBB', to: ACCOUNT_ID }))
+
+    // Trigger a stream error
+    capturedCallbacks.onerror!()
+    expect(onError).toHaveBeenCalledTimes(1)
+
+    // Before the timer fires, no reconnect yet
+    jest.advanceTimersByTime(999)
+    expect(mockStreamFn).toHaveBeenCalledTimes(1)
+
+    // After the initial 1s delay, reconnect fires
+    jest.advanceTimersByTime(1)
+    expect(mockStreamFn).toHaveBeenCalledTimes(2)
+
+    // Reconnect must resume from the last seen paging_token, not 'now'
+    expect(capturedCursors[1]).toBe('pt-42')
+
+    feed.stop()
+  })
+
+  it('applies exponential backoff on repeated stream failures', () => {
+    createActivityFeed({
+      accountId: ACCOUNT_ID,
+      horizonUrl: 'https://horizon-testnet.stellar.org',
+      onEvent: jest.fn(),
+    })
+
+    // 1st error: reconnect after 1 000 ms
+    capturedCallbacks.onerror!()
+    jest.advanceTimersByTime(1_000)
+    expect(mockStreamFn).toHaveBeenCalledTimes(2)
+
+    // 2nd error: reconnect after 2 000 ms
+    capturedCallbacks.onerror!()
+    jest.advanceTimersByTime(1_999)
+    expect(mockStreamFn).toHaveBeenCalledTimes(2)
+    jest.advanceTimersByTime(1)
+    expect(mockStreamFn).toHaveBeenCalledTimes(3)
+
+    // 3rd error: reconnect after 4 000 ms
+    capturedCallbacks.onerror!()
+    jest.advanceTimersByTime(3_999)
+    expect(mockStreamFn).toHaveBeenCalledTimes(3)
+    jest.advanceTimersByTime(1)
+    expect(mockStreamFn).toHaveBeenCalledTimes(4)
+  })
+
+  it('caps reconnect delay at 30 000 ms', () => {
+    createActivityFeed({
+      accountId: ACCOUNT_ID,
+      horizonUrl: 'https://horizon-testnet.stellar.org',
+      onEvent: jest.fn(),
+    })
+
+    // Exhaust all doubling steps until the cap
+    let delay = 1_000
+    while (delay < 30_000) {
+      capturedCallbacks.onerror!()
+      jest.advanceTimersByTime(delay)
+      delay = Math.min(delay * 2, 30_000)
+    }
+    const callsBeforeCap = mockStreamFn.mock.calls.length
+
+    // Subsequent errors must not exceed 30 000 ms
+    capturedCallbacks.onerror!()
+    jest.advanceTimersByTime(29_999)
+    expect(mockStreamFn).toHaveBeenCalledTimes(callsBeforeCap)
+    jest.advanceTimersByTime(1)
+    expect(mockStreamFn).toHaveBeenCalledTimes(callsBeforeCap + 1)
+  })
+
+  it('stops the stream and cancels pending reconnect on stop()', () => {
+    const feed = createActivityFeed({
+      accountId: ACCOUNT_ID,
+      horizonUrl: 'https://horizon-testnet.stellar.org',
+      onEvent: jest.fn(),
+    })
+
+    // Trigger an error to queue a reconnect, then stop before it fires
+    capturedCallbacks.onerror!()
+    feed.stop()
+
+    jest.runAllTimers()
+
+    // Stream must not have been reopened
+    expect(mockStreamFn).toHaveBeenCalledTimes(1)
+    expect(mockStopStream).toHaveBeenCalledTimes(1)
+  })
+
+  it('resets the reconnect delay after a successful message', () => {
+    createActivityFeed({
+      accountId: ACCOUNT_ID,
+      horizonUrl: 'https://horizon-testnet.stellar.org',
+      onEvent: jest.fn(),
+    })
+
+    // Drive the delay up to 2 000 ms with two errors
+    capturedCallbacks.onerror!()
+    jest.advanceTimersByTime(1_000)
+    capturedCallbacks.onerror!()
+    jest.advanceTimersByTime(2_000)
+    expect(mockStreamFn).toHaveBeenCalledTimes(3)
+
+    // A successful message resets the delay back to 1 000 ms
+    capturedCallbacks.onmessage!(makeOp({ from: 'GBBB', to: ACCOUNT_ID }))
+
+    capturedCallbacks.onerror!()
+    jest.advanceTimersByTime(999)
+    expect(mockStreamFn).toHaveBeenCalledTimes(3)
+    jest.advanceTimersByTime(1)
+    expect(mockStreamFn).toHaveBeenCalledTimes(4)
+  })
+})

--- a/sdk/src/events.ts
+++ b/sdk/src/events.ts
@@ -1,0 +1,152 @@
+import { Horizon } from '@stellar/stellar-sdk'
+
+export type ActivityEventType =
+  | 'payment_received'
+  | 'payment_sent'
+  | 'account_created'
+  | 'path_payment'
+
+export interface ActivityEvent {
+  id: string
+  type: ActivityEventType
+  amount: string
+  asset: string
+  counterparty: string
+  timestamp: number
+  hash: string
+  memo?: string
+  destAmount?: string
+  destAsset?: string
+}
+
+export interface ActivityFeedConfig {
+  accountId: string
+  horizonUrl: string
+  onEvent: (event: ActivityEvent) => void
+  onError?: (err: Error) => void
+}
+
+export interface ActivityFeed {
+  stop: () => void
+}
+
+export interface RawHorizonOp {
+  id: string
+  paging_token: string
+  type: string
+  from?: string
+  to?: string
+  funder?: string
+  amount?: string
+  starting_balance?: string
+  asset_type?: string
+  asset_code?: string
+  source_amount?: string
+  source_asset_type?: string
+  source_asset_code?: string
+  created_at: string
+  transaction_hash: string
+  transaction?: { memo?: string }
+}
+
+export function mapHorizonOpToEvent(op: RawHorizonOp, accountId: string): ActivityEvent | null {
+  if (op.type === 'create_account') {
+    return {
+      id: op.paging_token,
+      type: 'account_created',
+      amount: op.starting_balance ?? '0',
+      asset: 'XLM',
+      counterparty: op.funder ?? 'Friendbot',
+      timestamp: Math.floor(new Date(op.created_at).getTime() / 1000),
+      hash: op.transaction_hash,
+    }
+  }
+
+  if (op.type === 'path_payment_strict_send') {
+    const srcAsset = op.source_asset_type === 'native' ? 'XLM' : (op.source_asset_code ?? 'XLM')
+    const dstAsset = op.asset_type === 'native' ? 'XLM' : (op.asset_code ?? '')
+    return {
+      id: op.paging_token,
+      type: 'path_payment',
+      amount: op.source_amount ?? '0',
+      asset: srcAsset,
+      destAmount: op.amount ?? '0',
+      destAsset: dstAsset,
+      counterparty: 'Stellar DEX',
+      timestamp: Math.floor(new Date(op.created_at).getTime() / 1000),
+      hash: op.transaction_hash,
+    }
+  }
+
+  if (op.type === 'payment') {
+    const isSent = op.from === accountId
+    const asset = op.asset_type === 'native' ? 'XLM' : (op.asset_code ?? '')
+    return {
+      id: op.paging_token,
+      type: isSent ? 'payment_sent' : 'payment_received',
+      amount: op.amount ?? '0',
+      asset,
+      counterparty: isSent ? (op.to ?? '') : (op.from ?? ''),
+      timestamp: Math.floor(new Date(op.created_at).getTime() / 1000),
+      hash: op.transaction_hash,
+      memo: op.transaction?.memo,
+    }
+  }
+
+  return null
+}
+
+export function createActivityFeed(config: ActivityFeedConfig): ActivityFeed {
+  const { accountId, horizonUrl, onEvent, onError } = config
+
+  let stopped = false
+  let stopStream: (() => void) | null = null
+  let lastCursor = 'now'
+  let reconnectTimer: ReturnType<typeof setTimeout> | null = null
+  let reconnectDelay = 1_000
+  const MAX_RECONNECT_DELAY = 30_000
+
+  const server = new Horizon.Server(horizonUrl)
+
+  function connect(): void {
+    if (stopped) return
+
+    stopStream = server
+      .payments()
+      .forAccount(accountId)
+      .cursor(lastCursor)
+      .stream({
+        onmessage(op: any) {
+          reconnectDelay = 1_000
+          lastCursor = op.paging_token as string
+          const event = mapHorizonOpToEvent(op as RawHorizonOp, accountId)
+          if (event) onEvent(event)
+        },
+        onerror() {
+          if (stopped) return
+          stopStream?.()
+          stopStream = null
+          onError?.(new Error('Activity stream disconnected'))
+          scheduleReconnect()
+        },
+      })
+  }
+
+  function scheduleReconnect(): void {
+    if (stopped) return
+    reconnectTimer = setTimeout(() => {
+      reconnectDelay = Math.min(reconnectDelay * 2, MAX_RECONNECT_DELAY)
+      connect()
+    }, reconnectDelay)
+  }
+
+  connect()
+
+  return {
+    stop() {
+      stopped = true
+      if (reconnectTimer) clearTimeout(reconnectTimer)
+      stopStream?.()
+    },
+  }
+}


### PR DESCRIPTION
Closes #320

## Summary

- Adds `sdk/src/events.ts`: exports `mapHorizonOpToEvent` (maps raw Horizon ops to typed `ActivityEvent` records) and `createActivityFeed` (opens a Horizon SSE stream with exponential-backoff reconnect, resuming from the last seen paging token to prevent gaps or duplicates)
- Adds `frontend/wallet/lib/activityFeed.ts`: module-level pub/sub store (`initActivityFeed`, `hydrateActivityFeed`, `subscribeActivityFeed`, `useActivityFeed`) that wraps the SDK feed and converts events to the dashboard's `TxRecord` shape
- Updates `frontend/wallet/app/dashboard/page.tsx`: swaps manual `transactions` state for `useActivityFeed()`, seeds the feed with the initial history fetch, and starts the live stream once the fee-payer key is known
- Adds `sdk/src/__tests__/events.test.ts`: 15 unit tests covering the event mapper (all op types, edge cases) and the reconnect state machine (backoff timing, cursor resume, cap at 30 s, stop cancels reconnect)

## Test plan

- [ ] Run `cd sdk && npm test` - all events tests pass
- [ ] Open the wallet dashboard and send/receive XLM on testnet - new transactions appear in the activity feed without a manual refresh
- [ ] Disconnect network briefly and reconnect - the stream recovers automatically and no events are duplicated
- [ ] Navigate away from dashboard and back - activity list renders instantly from module cache, then stream continues