### PR TITLE
Add create-veil-app CLI scaffolder

### DIFF
--- a/packages/create-veil-app/.gitignore
+++ b/packages/create-veil-app/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/packages/create-veil-app/README.md
+++ b/packages/create-veil-app/README.md
@@ -1,0 +1,55 @@
+# create-veil-app
+
+Scaffold a new [Veil](https://github.com/Miracle656/veil) passkey-wallet app
+from a template — `npx create-veil-app my-app` gives you a working,
+installed project in about 30 seconds.
+
+## Usage
+
+```bash
+npx create-veil-app my-app
+```
+
+You'll be prompted to choose a template if you don't pass `--template`:
+
+```bash
+npx create-veil-app my-app --template=next     # Next.js
+npx create-veil-app my-app --template=vite     # Vite + React
+npx create-veil-app my-app --template=vanilla  # Vanilla JS, no framework
+```
+
+Each command:
+
+1. Fetches the chosen template from [`examples/`](../../examples) in the
+   Veil repo.
+2. Vendors the [`sdk/`](../../sdk) package alongside it (the Stellar +
+   WebAuthn SDK isn't published to npm yet, so it's fetched and built
+   locally instead of installed from the registry).
+3. Builds the SDK and installs the app's dependencies.
+
+When it finishes, `cd my-app` and follow the printed next step (`npm run
+dev`, or serve `index.html` for the vanilla template). Each template's own
+README documents the environment variables it needs (factory contract
+address, RPC URL, etc.).
+
+## Requirements
+
+- Node.js 20+
+
+## Local development
+
+This package isn't published yet. To run it from a checkout of this repo:
+
+```bash
+cd packages/create-veil-app
+npm install
+npm run build
+node dist/index.js my-app --template=vite
+```
+
+Set `VEIL_TEMPLATE_REPO` to point at a different GitHub `owner/repo` (e.g.
+your own fork) if you're testing template changes before they're merged:
+
+```bash
+VEIL_TEMPLATE_REPO=your-username/veil node dist/index.js my-app --template=vite
+```

--- a/packages/create-veil-app/dist/index.js
+++ b/packages/create-veil-app/dist/index.js
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import degit from 'degit';
+import prompts from 'prompts';
+const REPO = process.env.VEIL_TEMPLATE_REPO ?? 'Miracle656/veil';
+const TEMPLATES = {
+    next: { label: 'Next.js', dir: 'examples/nextjs' },
+    vite: { label: 'Vite + React', dir: 'examples/vite-react' },
+    vanilla: { label: 'Vanilla JS', dir: 'examples/vanilla' },
+};
+function isTemplateKey(value) {
+    return value in TEMPLATES;
+}
+function run(cmd, args, cwd) {
+    return new Promise((resolve, reject) => {
+        const child = spawn(cmd, args, {
+            cwd,
+            stdio: 'inherit',
+            shell: process.platform === 'win32',
+        });
+        child.on('error', reject);
+        child.on('exit', code => {
+            if (code === 0)
+                resolve();
+            else
+                reject(new Error(`"${cmd} ${args.join(' ')}" exited with code ${code}`));
+        });
+    });
+}
+function replaceInFile(filePath, search, replace) {
+    if (!fs.existsSync(filePath))
+        return;
+    const contents = fs.readFileSync(filePath, 'utf8');
+    fs.writeFileSync(filePath, contents.split(search).join(replace));
+}
+// The vendored sdk/ is consumed as a built dependency, not project source.
+// Without this, a template's own tsconfig.json (e.g. Next.js's "**/*.ts"
+// include) sweeps up the SDK's raw TypeScript and type-checks it against
+// the app's compiler target, which can fail (e.g. ES2017 vs. the SDK's
+// ES2020 BigInt literals).
+function excludeSdkFromTsconfig(targetDir) {
+    const tsconfigPath = path.join(targetDir, 'tsconfig.json');
+    if (!fs.existsSync(tsconfigPath))
+        return;
+    try {
+        const config = JSON.parse(fs.readFileSync(tsconfigPath, 'utf8'));
+        const exclude = Array.isArray(config.exclude) ? config.exclude : [];
+        if (!exclude.includes('sdk'))
+            exclude.push('sdk');
+        config.exclude = exclude;
+        fs.writeFileSync(tsconfigPath, `${JSON.stringify(config, null, 2)}\n`);
+    }
+    catch {
+        console.warn('Could not update tsconfig.json to exclude sdk/ — you may need to add it manually.');
+    }
+}
+function parseArgs(argv) {
+    const positionals = [];
+    let template;
+    for (const arg of argv) {
+        if (arg.startsWith('--template='))
+            template = arg.slice('--template='.length);
+        else if (!arg.startsWith('-'))
+            positionals.push(arg);
+    }
+    return { name: positionals[0], template };
+}
+async function main() {
+    const { name: nameArg, template: templateArg } = parseArgs(process.argv.slice(2));
+    let name = nameArg;
+    if (!name) {
+        const response = await prompts({ type: 'text', name: 'name', message: 'Project name', initial: 'my-veil-app' }, { onCancel: () => process.exit(1) });
+        name = response.name;
+    }
+    if (!name) {
+        console.error('A project name is required.');
+        process.exit(1);
+    }
+    const targetDir = path.resolve(process.cwd(), name);
+    if (fs.existsSync(targetDir) && fs.readdirSync(targetDir).length > 0) {
+        console.error(`Directory "${name}" already exists and is not empty.`);
+        process.exit(1);
+    }
+    let template = templateArg;
+    if (!template || !isTemplateKey(template)) {
+        const response = await prompts({
+            type: 'select',
+            name: 'template',
+            message: 'Choose a template',
+            choices: Object.entries(TEMPLATES).map(([value, { label }]) => ({ title: label, value })),
+        }, { onCancel: () => process.exit(1) });
+        template = response.template;
+    }
+    if (!template || !isTemplateKey(template)) {
+        console.error(`A template choice is required. Available: ${Object.keys(TEMPLATES).join(', ')}`);
+        process.exit(1);
+    }
+    const { dir, label } = TEMPLATES[template];
+    console.log(`\nScaffolding ${label} app in ./${name}...\n`);
+    await degit(`${REPO}/${dir}`, { force: true }).clone(targetDir);
+    console.log('Fetching the Veil SDK...');
+    await degit(`${REPO}/sdk`, { force: true }).clone(path.join(targetDir, 'sdk'));
+    // Templates reference the SDK from the monorepo (file:../../sdk); once
+    // scaffolded standalone the SDK lives at ./sdk instead.
+    replaceInFile(path.join(targetDir, 'package.json'), 'file:../../sdk', 'file:./sdk');
+    replaceInFile(path.join(targetDir, 'index.html'), '../../sdk/dist/vanilla.js', './sdk/dist/vanilla.js');
+    excludeSdkFromTsconfig(targetDir);
+    console.log('Installing SDK dependencies and building...');
+    await run('npm', ['install'], path.join(targetDir, 'sdk'));
+    await run('npm', ['run', 'build'], path.join(targetDir, 'sdk'));
+    if (fs.existsSync(path.join(targetDir, 'package.json'))) {
+        console.log('Installing app dependencies...');
+        await run('npm', ['install'], targetDir);
+    }
+    console.log(`\nDone! Next steps:\n`);
+    console.log(`  cd ${name}`);
+    console.log(template === 'vanilla' ? '  npx http-server .   # or any static file server' : '  npm run dev');
+    console.log(`\nSee ${name}/README.md for environment variables (factory address, RPC URL, etc.).\n`);
+}
+main().catch(err => {
+    console.error(err instanceof Error ? err.message : err);
+    process.exit(1);
+});

--- a/packages/create-veil-app/package-lock.json
+++ b/packages/create-veil-app/package-lock.json
@@ -1,0 +1,629 @@
+{
+  "name": "create-veil-app",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "create-veil-app",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "degit": "^3.4.7",
+        "prompts": "^2.4.2"
+      },
+      "bin": {
+        "create-veil-app": "dist/index.js"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "@types/prompts": "^2.4.9",
+        "tsx": "^4.22.3",
+        "typescript": "^5.6.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/prompts": {
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/@types/prompts/-/prompts-2.4.9.tgz",
+      "integrity": "sha512-qTxFi6Buiu8+50/+3DGIWLHM6QuWsEKugJnnP6iv2Mc4ncxE4A/OJkjuVOA+5X0X1S/nq5VJRa8Lu+nwcvbrKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "kleur": "^3.0.3"
+      }
+    },
+    "node_modules/degit": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/degit/-/degit-3.4.7.tgz",
+      "integrity": "sha512-jcFOCSHRTzxTS99A26nSbv+/3YfEhTo3qhDJGk7QvaIP1BxOqZJgfWefWw9CINgEQjY0L/iA9yXC4CN2LcdnlA==",
+      "license": "MIT",
+      "bin": {
+        "degit": "degit"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "license": "MIT"
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/packages/create-veil-app/package.json
+++ b/packages/create-veil-app/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "create-veil-app",
+  "version": "0.1.0",
+  "description": "Scaffold a new Veil passkey-wallet app from a template (Next.js, Vite, or vanilla JS)",
+  "type": "module",
+  "bin": {
+    "create-veil-app": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc && chmod +x dist/index.js",
+    "dev": "tsx src/index.ts",
+    "prepublishOnly": "npm run build"
+  },
+  "keywords": [
+    "stellar",
+    "soroban",
+    "webauthn",
+    "passkeys",
+    "wallet",
+    "scaffolder",
+    "cli",
+    "create-app"
+  ],
+  "license": "MIT",
+  "engines": {
+    "node": ">=20"
+  },
+  "dependencies": {
+    "degit": "^3.4.7",
+    "prompts": "^2.4.2"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "@types/prompts": "^2.4.9",
+    "tsx": "^4.22.3",
+    "typescript": "^5.6.2"
+  }
+}

--- a/packages/create-veil-app/src/index.ts
+++ b/packages/create-veil-app/src/index.ts
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import degit from 'degit';
+import prompts from 'prompts';
+
+const REPO = process.env.VEIL_TEMPLATE_REPO ?? 'Miracle656/veil';
+
+const TEMPLATES = {
+  next: { label: 'Next.js', dir: 'examples/nextjs' },
+  vite: { label: 'Vite + React', dir: 'examples/vite-react' },
+  vanilla: { label: 'Vanilla JS', dir: 'examples/vanilla' },
+} as const;
+
+type TemplateKey = keyof typeof TEMPLATES;
+
+function isTemplateKey(value: string): value is TemplateKey {
+  return value in TEMPLATES;
+}
+
+function run(cmd: string, args: string[], cwd: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, {
+      cwd,
+      stdio: 'inherit',
+      shell: process.platform === 'win32',
+    });
+    child.on('error', reject);
+    child.on('exit', code => {
+      if (code === 0) resolve();
+      else reject(new Error(`"${cmd} ${args.join(' ')}" exited with code ${code}`));
+    });
+  });
+}
+
+function replaceInFile(filePath: string, search: string, replace: string) {
+  if (!fs.existsSync(filePath)) return;
+  const contents = fs.readFileSync(filePath, 'utf8');
+  fs.writeFileSync(filePath, contents.split(search).join(replace));
+}
+
+// The vendored sdk/ is consumed as a built dependency, not project source.
+// Without this, a template's own tsconfig.json (e.g. Next.js's "**/*.ts"
+// include) sweeps up the SDK's raw TypeScript and type-checks it against
+// the app's compiler target, which can fail (e.g. ES2017 vs. the SDK's
+// ES2020 BigInt literals).
+function excludeSdkFromTsconfig(targetDir: string) {
+  const tsconfigPath = path.join(targetDir, 'tsconfig.json');
+  if (!fs.existsSync(tsconfigPath)) return;
+  try {
+    const config = JSON.parse(fs.readFileSync(tsconfigPath, 'utf8'));
+    const exclude: string[] = Array.isArray(config.exclude) ? config.exclude : [];
+    if (!exclude.includes('sdk')) exclude.push('sdk');
+    config.exclude = exclude;
+    fs.writeFileSync(tsconfigPath, `${JSON.stringify(config, null, 2)}\n`);
+  } catch {
+    console.warn('Could not update tsconfig.json to exclude sdk/ — you may need to add it manually.');
+  }
+}
+
+function parseArgs(argv: string[]) {
+  const positionals: string[] = [];
+  let template: string | undefined;
+
+  for (const arg of argv) {
+    if (arg.startsWith('--template=')) template = arg.slice('--template='.length);
+    else if (!arg.startsWith('-')) positionals.push(arg);
+  }
+
+  return { name: positionals[0], template };
+}
+
+async function main() {
+  const { name: nameArg, template: templateArg } = parseArgs(process.argv.slice(2));
+
+  let name = nameArg;
+  if (!name) {
+    const response = await prompts(
+      { type: 'text', name: 'name', message: 'Project name', initial: 'my-veil-app' },
+      { onCancel: () => process.exit(1) },
+    );
+    name = response.name;
+  }
+  if (!name) {
+    console.error('A project name is required.');
+    process.exit(1);
+  }
+
+  const targetDir = path.resolve(process.cwd(), name);
+  if (fs.existsSync(targetDir) && fs.readdirSync(targetDir).length > 0) {
+    console.error(`Directory "${name}" already exists and is not empty.`);
+    process.exit(1);
+  }
+
+  let template = templateArg;
+  if (!template || !isTemplateKey(template)) {
+    const response = await prompts(
+      {
+        type: 'select',
+        name: 'template',
+        message: 'Choose a template',
+        choices: Object.entries(TEMPLATES).map(([value, { label }]) => ({ title: label, value })),
+      },
+      { onCancel: () => process.exit(1) },
+    );
+    template = response.template;
+  }
+  if (!template || !isTemplateKey(template)) {
+    console.error(`A template choice is required. Available: ${Object.keys(TEMPLATES).join(', ')}`);
+    process.exit(1);
+  }
+
+  const { dir, label } = TEMPLATES[template];
+
+  console.log(`\nScaffolding ${label} app in ./${name}...\n`);
+  await degit(`${REPO}/${dir}`, { force: true }).clone(targetDir);
+
+  console.log('Fetching the Veil SDK...');
+  await degit(`${REPO}/sdk`, { force: true }).clone(path.join(targetDir, 'sdk'));
+
+  // Templates reference the SDK from the monorepo (file:../../sdk); once
+  // scaffolded standalone the SDK lives at ./sdk instead.
+  replaceInFile(path.join(targetDir, 'package.json'), 'file:../../sdk', 'file:./sdk');
+  replaceInFile(path.join(targetDir, 'index.html'), '../../sdk/dist/vanilla.js', './sdk/dist/vanilla.js');
+  excludeSdkFromTsconfig(targetDir);
+
+  console.log('Installing SDK dependencies and building...');
+  await run('npm', ['install'], path.join(targetDir, 'sdk'));
+  await run('npm', ['run', 'build'], path.join(targetDir, 'sdk'));
+
+  if (fs.existsSync(path.join(targetDir, 'package.json'))) {
+    console.log('Installing app dependencies...');
+    await run('npm', ['install'], targetDir);
+  }
+
+  console.log(`\nDone! Next steps:\n`);
+  console.log(`  cd ${name}`);
+  console.log(template === 'vanilla' ? '  npx http-server .   # or any static file server' : '  npm run dev');
+  console.log(`\nSee ${name}/README.md for environment variables (factory address, RPC URL, etc.).\n`);
+}
+
+main().catch(err => {
+  console.error(err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/packages/create-veil-app/tsconfig.json
+++ b/packages/create-veil-app/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*"]
+}

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -27,7 +27,7 @@
     "src"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && node scripts/flatten-dist.js",
     "test": "jest",
     "size": "npm run build && size-limit",
     "test:surface": "jest api-surface.test.ts",

--- a/sdk/scripts/flatten-dist.js
+++ b/sdk/scripts/flatten-dist.js
@@ -1,0 +1,15 @@
+// tsconfig.json compiles src/ and react/ together so react's cross-imports
+// into src/ type-check, which makes tsc nest src output under dist/src/.
+// package.json's main/exports expect it at dist/ directly, so move it up.
+const fs = require('node:fs');
+const path = require('node:path');
+
+const distDir = path.join(__dirname, '..', 'dist');
+const nestedSrcDir = path.join(distDir, 'src');
+
+if (fs.existsSync(nestedSrcDir)) {
+  for (const entry of fs.readdirSync(nestedSrcDir)) {
+    fs.renameSync(path.join(nestedSrcDir, entry), path.join(distDir, entry));
+  }
+  fs.rmdirSync(nestedSrcDir);
+}


### PR DESCRIPTION
Closes #340

## Summary
- Adds `packages/create-veil-app/` — a CLI scaffolder (`npx create-veil-app my-app`) that prompts for a project name and template (Next.js, Vite + React, or vanilla JS), fetches the chosen `examples/` template via `degit`, and produces a working, installed project.
- The Veil SDK isn't published to npm yet, so the CLI also `degit`s the `sdk/` package alongside the template, rewrites the template's `file:../../sdk` dependency to `file:./sdk`, and builds it locally — rather than leaving the user with a broken install.
- For templates with their own `tsconfig.json` (e.g. Next.js), adds `sdk` to `exclude` — otherwise the app's TS compiler sweeps up the SDK's raw source via `**/*.ts` and type-checks it against the app's (older) target, which fails on the SDK's ES2020 BigInt literals.
- Also carries the `sdk/` dist-output fix from #346 (`tsc` nests `src/` output under `dist/src/` instead of `dist/`, so `package.json`'s `main: "dist/index.js"` never resolves) since every scaffolded app depends on it to build. If #346 merges first this will be a no-op overlap; if this merges first, #346 still applies cleanly.

## Test plan
- [x] `vite` template: scaffolded, vendored SDK built, `npm run build` (renderer) succeeds, `vite` dev server boots and serves `src/main.tsx`
- [x] `next` template: scaffolded, vendored SDK built, `next build` succeeds (including the `tsconfig.json` exclude fix — first attempt without it failed on `sdk/src/sep7.ts`'s BigInt literal)
- [x] `vanilla` template: scaffolded, `index.html`'s SDK import path rewritten to `./sdk/dist/vanilla.js`
- [x] Confirmed the CLI errors cleanly on an existing non-empty target directory and on an invalid `--template` value