### PR TITLE
feat(wallet): configurable inactive-session auto-lock (#351)

### DIFF
--- a/frontend/wallet/app/lock/page.tsx
+++ b/frontend/wallet/app/lock/page.tsx
@@ -117,7 +117,7 @@ export default function LockPage() {
               Wallet locked
             </h1>
             <p style={{ fontSize: '0.875rem', color: 'rgba(246,247,248,0.45)', lineHeight: 1.6 }}>
-              Your session ended after 5 minutes of inactivity.
+              Your session was locked after a period of inactivity.
               <br />
               Verify your identity to continue.
             </p>

--- a/frontend/wallet/app/settings/page.tsx
+++ b/frontend/wallet/app/settings/page.tsx
@@ -475,6 +475,25 @@ export default function SettingsPage() {
                 </div>
               </button>
 
+              {/* Security & Lock */}
+              <button
+                className="card"
+                onClick={() => router.push('/settings/security')}
+                style={{ textAlign: 'left', cursor: 'pointer', width: '100%', border: '1px solid var(--border-dim)', background: 'var(--surface)' }}
+              >
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                  <div>
+                    <p style={{ fontWeight: 500, fontSize: '0.9375rem' }}>Security &amp; Lock</p>
+                    <p style={{ fontSize: '0.8125rem', color: 'rgba(246,247,248,0.4)', marginTop: '0.25rem' }}>
+                      Auto-lock the wallet after inactivity
+                    </p>
+                  </div>
+                  <svg width="16" height="16" viewBox="0 0 16 16" fill="none" style={{ flexShrink: 0 }}>
+                    <path d="M6 3l5 5-5 5" stroke="rgba(246,247,248,0.3)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+                  </svg>
+                </div>
+              </button>
+
               {/* Address Book card */}
               <button
                 className="card"

--- a/frontend/wallet/app/settings/security/page.tsx
+++ b/frontend/wallet/app/settings/security/page.tsx
@@ -1,0 +1,114 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { ChevronLeft, LockKeyhole, Check } from 'lucide-react'
+import { useInactivityLock } from '@/hooks/useInactivityLock'
+import {
+  type IdleTimeout,
+  IDLE_TIMEOUT_OPTIONS,
+  DEFAULT_IDLE_TIMEOUT,
+  getIdleTimeout,
+  setIdleTimeout,
+} from '@/lib/idle-lock'
+
+function optionLabel(option: IdleTimeout): string {
+  return option === 'never' ? 'Never' : `${option} minutes`
+}
+
+const OPTION_DESC: Record<string, string> = {
+  '5': 'Most secure',
+  '15': 'Recommended',
+  '30': 'Relaxed',
+  never: 'Not recommended — auto-lock disabled',
+}
+
+export default function SecuritySettingsPage() {
+  const router = useRouter()
+  useInactivityLock()
+
+  // Read the persisted value after mount to avoid a hydration mismatch.
+  const [selected, setSelected] = useState<IdleTimeout>(DEFAULT_IDLE_TIMEOUT)
+  useEffect(() => {
+    setSelected(getIdleTimeout())
+  }, [])
+
+  function choose(option: IdleTimeout) {
+    setIdleTimeout(option)
+    setSelected(option)
+  }
+
+  return (
+    <div className="wallet-shell" style={{ padding: '1.5rem 1.25rem 4rem' }}>
+      <div style={{ maxWidth: 480, width: '100%', margin: '0 auto' }}>
+        {/* Header */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', marginBottom: '1.75rem' }}>
+          <button
+            type="button"
+            onClick={() => router.push('/settings')}
+            aria-label="Back to settings"
+            style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--off-white)', display: 'flex', padding: 0 }}
+          >
+            <ChevronLeft size={22} strokeWidth={1.75} />
+          </button>
+          <h1 style={{ fontFamily: 'Lora, Georgia, serif', fontWeight: 600, fontStyle: 'italic', fontSize: '1.375rem', color: 'var(--off-white)' }}>
+            Security
+          </h1>
+        </div>
+
+        {/* Auto-lock section */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.625rem', marginBottom: '0.5rem' }}>
+          <LockKeyhole size={16} color="var(--gold)" strokeWidth={1.75} />
+          <p style={{ fontFamily: 'Anton, Impact, sans-serif', letterSpacing: '0.06em', fontSize: '0.75rem', color: 'rgba(246,247,248,0.5)' }}>
+            AUTO-LOCK
+          </p>
+        </div>
+        <p style={{ fontSize: '0.8125rem', color: 'rgba(246,247,248,0.4)', lineHeight: 1.6, marginBottom: '1rem' }}>
+          Lock the wallet and require your passkey again after a period of inactivity. Switching
+          tabs or apps restarts the timer.
+        </p>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '0.625rem' }}>
+          {IDLE_TIMEOUT_OPTIONS.map((option) => {
+            const isSelected = option === selected
+            return (
+              <button
+                key={String(option)}
+                type="button"
+                onClick={() => choose(option)}
+                className="card"
+                aria-pressed={isSelected}
+                style={{
+                  textAlign: 'left',
+                  cursor: 'pointer',
+                  width: '100%',
+                  background: 'var(--surface)',
+                  border: `1px solid ${isSelected ? 'var(--gold)' : 'var(--border-dim)'}`,
+                }}
+              >
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '0.75rem' }}>
+                  <div>
+                    <p style={{ fontWeight: 500, fontSize: '0.9375rem', color: 'var(--off-white)' }}>
+                      {optionLabel(option)}
+                    </p>
+                    <p style={{ fontSize: '0.8125rem', color: 'rgba(246,247,248,0.4)', marginTop: '0.25rem' }}>
+                      {OPTION_DESC[String(option)]}
+                    </p>
+                  </div>
+                  {isSelected && <Check size={18} color="var(--gold)" strokeWidth={2} style={{ flexShrink: 0 }} />}
+                </div>
+              </button>
+            )
+          })}
+        </div>
+
+        {selected === 'never' && (
+          <p style={{ fontSize: '0.75rem', color: 'rgba(252,165,165,0.9)', marginTop: '1rem', lineHeight: 1.5 }}>
+            With auto-lock off, anyone with access to this device can use your wallet without
+            re-verifying. Only choose this on a device you fully trust.
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/wallet/hooks/useInactivityLock.ts
+++ b/frontend/wallet/hooks/useInactivityLock.ts
@@ -1,35 +1,30 @@
-import { useEffect, useRef, useCallback } from 'react'
+import { useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { txActive } from '@/lib/txState'
+import { createIdleWatcher } from '@/lib/idle-lock'
 
-const LOCK_TIMEOUT_MS = 5 * 60 * 1000
-const ACTIVITY_EVENTS = ['mousemove', 'keydown', 'touchstart', 'click', 'scroll'] as const
-
+/**
+ * Locks the wallet after a configurable period of inactivity.
+ *
+ * Behaviour and the timeout itself live in `lib/idle-lock.ts`; this hook just
+ * wires the watcher to Next's router and the session store. On lock it clears
+ * in-memory session state and routes to `/lock`, which re-prompts the passkey.
+ * The timeout (5 / 15 / 30 minutes, or never) is configured in
+ * Settings → Security and applied immediately.
+ */
 export function useInactivityLock() {
-  const router   = useRouter()
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-
-  const lock = useCallback(() => {
-    // Never interrupt an in-flight transaction — reschedule and check again
-    if (txActive()) {
-      timerRef.current = setTimeout(lock, 35_000)
-      return
-    }
-    sessionStorage.clear()
-    router.replace('/lock')
-  }, [router])
-
-  const resetTimer = useCallback(() => {
-    if (timerRef.current) clearTimeout(timerRef.current)
-    timerRef.current = setTimeout(lock, LOCK_TIMEOUT_MS)
-  }, [lock])
+  const router = useRouter()
 
   useEffect(() => {
-    resetTimer()
-    ACTIVITY_EVENTS.forEach(e => window.addEventListener(e, resetTimer, { passive: true }))
-    return () => {
-      if (timerRef.current) clearTimeout(timerRef.current)
-      ACTIVITY_EVENTS.forEach(e => window.removeEventListener(e, resetTimer))
-    }
-  }, [resetTimer])
+    const watcher = createIdleWatcher({
+      onLock: () => {
+        sessionStorage.clear()
+        router.replace('/lock')
+      },
+      // Never lock mid-transaction.
+      shouldDefer: txActive,
+    })
+    watcher.start()
+    return () => watcher.stop()
+  }, [router])
 }

--- a/frontend/wallet/lib/__tests__/idle-lock.test.ts
+++ b/frontend/wallet/lib/__tests__/idle-lock.test.ts
@@ -1,0 +1,143 @@
+import {
+  createIdleWatcher,
+  getIdleTimeout,
+  setIdleTimeout,
+  idleTimeoutToMs,
+  DEFAULT_IDLE_TIMEOUT,
+} from '../idle-lock'
+
+describe('idle-lock timeout config', () => {
+  beforeEach(() => localStorage.clear())
+
+  it('defaults to 5 minutes', () => {
+    expect(getIdleTimeout()).toBe(5)
+    expect(DEFAULT_IDLE_TIMEOUT).toBe(5)
+  })
+
+  it('round-trips each valid option (5 / 15 / 30 / never)', () => {
+    for (const option of [5, 15, 30, 'never'] as const) {
+      setIdleTimeout(option)
+      expect(getIdleTimeout()).toBe(option)
+    }
+  })
+
+  it('falls back to the default for an invalid stored value', () => {
+    localStorage.setItem('veil_idle_lock_minutes', '999')
+    expect(getIdleTimeout()).toBe(5)
+  })
+
+  it('maps options to milliseconds (never → null)', () => {
+    expect(idleTimeoutToMs(5)).toBe(5 * 60 * 1000)
+    expect(idleTimeoutToMs(30)).toBe(30 * 60 * 1000)
+    expect(idleTimeoutToMs('never')).toBeNull()
+  })
+})
+
+describe('createIdleWatcher', () => {
+  afterEach(() => {
+    jest.clearAllTimers()
+    jest.useRealTimers()
+    localStorage.clear()
+  })
+
+  it('locks after the idle timeout elapses', () => {
+    jest.useFakeTimers()
+    const onLock = jest.fn()
+    const watcher = createIdleWatcher({ onLock, getTimeoutMs: () => 1000 })
+    watcher.start()
+
+    jest.advanceTimersByTime(999)
+    expect(onLock).not.toHaveBeenCalled()
+    jest.advanceTimersByTime(1)
+    expect(onLock).toHaveBeenCalledTimes(1)
+    watcher.stop()
+  })
+
+  it('resets the timer on user activity', () => {
+    jest.useFakeTimers()
+    const onLock = jest.fn()
+    const watcher = createIdleWatcher({ onLock, getTimeoutMs: () => 1000 })
+    watcher.start()
+
+    jest.advanceTimersByTime(800)
+    window.dispatchEvent(new Event('keydown')) // activity → reset
+    jest.advanceTimersByTime(800)
+    expect(onLock).not.toHaveBeenCalled() // only 800ms since the reset
+    jest.advanceTimersByTime(200)
+    expect(onLock).toHaveBeenCalledTimes(1)
+    watcher.stop()
+  })
+
+  it('resets the timer on visibilitychange', () => {
+    jest.useFakeTimers()
+    const onLock = jest.fn()
+    const watcher = createIdleWatcher({ onLock, getTimeoutMs: () => 1000 })
+    watcher.start()
+
+    jest.advanceTimersByTime(700)
+    document.dispatchEvent(new Event('visibilitychange')) // reset
+    jest.advanceTimersByTime(700)
+    expect(onLock).not.toHaveBeenCalled()
+    jest.advanceTimersByTime(300)
+    expect(onLock).toHaveBeenCalledTimes(1)
+    watcher.stop()
+  })
+
+  it('never locks when the timeout is disabled (never)', () => {
+    jest.useFakeTimers()
+    const onLock = jest.fn()
+    const watcher = createIdleWatcher({ onLock, getTimeoutMs: () => null })
+    watcher.start()
+
+    jest.advanceTimersByTime(60 * 60 * 1000)
+    expect(onLock).not.toHaveBeenCalled()
+    watcher.stop()
+  })
+
+  it('defers locking while shouldDefer holds, then locks once clear', () => {
+    jest.useFakeTimers()
+    const onLock = jest.fn()
+    let busy = true
+    const watcher = createIdleWatcher({
+      onLock,
+      getTimeoutMs: () => 1000,
+      shouldDefer: () => busy,
+      deferMs: 500,
+    })
+    watcher.start()
+
+    jest.advanceTimersByTime(1000) // timeout fires, but busy → defer
+    expect(onLock).not.toHaveBeenCalled()
+    busy = false
+    jest.advanceTimersByTime(500) // defer elapses, no longer busy → lock
+    expect(onLock).toHaveBeenCalledTimes(1)
+    watcher.stop()
+  })
+
+  it('applies a timeout change immediately (config-changed event)', () => {
+    jest.useFakeTimers()
+    localStorage.clear()
+    const onLock = jest.fn()
+    // No getTimeoutMs override → reads the persisted setting (default 5 min).
+    const watcher = createIdleWatcher({ onLock })
+    watcher.start()
+
+    setIdleTimeout('never') // dispatches the change event → watcher disables
+    jest.advanceTimersByTime(60 * 60 * 1000)
+    expect(onLock).not.toHaveBeenCalled()
+    watcher.stop()
+  })
+
+  it('stops listening after stop()', () => {
+    jest.useFakeTimers()
+    const onLock = jest.fn()
+    const watcher = createIdleWatcher({ onLock, getTimeoutMs: () => 1000 })
+    watcher.start()
+    watcher.stop()
+
+    jest.advanceTimersByTime(5000)
+    window.dispatchEvent(new Event('keydown'))
+    jest.advanceTimersByTime(5000)
+    expect(onLock).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/wallet/lib/idle-lock.ts
+++ b/frontend/wallet/lib/idle-lock.ts
@@ -1,0 +1,116 @@
+// Inactive-session auto-lock.
+//
+// A framework-agnostic idle watcher: it listens for user activity
+// (mouse/keyboard/touch/scroll) and visibility changes, and fires `onLock` after
+// a configurable idle timeout. The timeout is persisted in localStorage and can
+// be changed at runtime (5 / 15 / 30 minutes, or never).
+
+export type IdleTimeout = 5 | 15 | 30 | 'never'
+
+export const IDLE_TIMEOUT_OPTIONS: readonly IdleTimeout[] = [5, 15, 30, 'never']
+export const DEFAULT_IDLE_TIMEOUT: IdleTimeout = 5
+
+const STORAGE_KEY = 'veil_idle_lock_minutes'
+
+/** Dispatched on `window` when the configured timeout changes, so live watchers reconfigure. */
+export const IDLE_TIMEOUT_CHANGED_EVENT = 'veil:idle-timeout-changed'
+
+const ACTIVITY_EVENTS = ['mousemove', 'keydown', 'touchstart', 'click', 'scroll'] as const
+const DEFAULT_DEFER_MS = 35_000
+
+/** Convert a timeout option to milliseconds, or null when auto-lock is disabled ('never'). */
+export function idleTimeoutToMs(timeout: IdleTimeout): number | null {
+  return timeout === 'never' ? null : timeout * 60 * 1000
+}
+
+/** Read the configured idle timeout, falling back to the default for missing/invalid values. */
+export function getIdleTimeout(): IdleTimeout {
+  if (typeof window === 'undefined') return DEFAULT_IDLE_TIMEOUT
+  const raw = window.localStorage.getItem(STORAGE_KEY)
+  if (raw === 'never') return 'never'
+  const minutes = Number(raw)
+  if (minutes === 5 || minutes === 15 || minutes === 30) return minutes
+  return DEFAULT_IDLE_TIMEOUT
+}
+
+/** Persist the idle timeout and notify any live watchers to apply it immediately. */
+export function setIdleTimeout(timeout: IdleTimeout): void {
+  if (typeof window === 'undefined') return
+  window.localStorage.setItem(STORAGE_KEY, String(timeout))
+  window.dispatchEvent(new CustomEvent(IDLE_TIMEOUT_CHANGED_EVENT))
+}
+
+export type IdleWatcherOptions = {
+  /** Called when the idle timeout elapses (and `shouldDefer` does not hold). */
+  onLock: () => void
+  /** When it returns true, locking is postponed (e.g. an in-flight transaction). */
+  shouldDefer?: () => boolean
+  /** How long to wait before re-checking when locking is deferred. Defaults to 35s. */
+  deferMs?: number
+  /** Current timeout in ms, or null to disable. Defaults to the persisted setting. */
+  getTimeoutMs?: () => number | null
+}
+
+export type IdleWatcher = {
+  start: () => void
+  stop: () => void
+  reset: () => void
+}
+
+/**
+ * Create an idle watcher. Call `start()` to begin listening and `stop()` to tear
+ * down. A user-activity event, a `visibilitychange`, or a timeout-config change
+ * all reset the countdown.
+ */
+export function createIdleWatcher(options: IdleWatcherOptions): IdleWatcher {
+  const getTimeoutMs = options.getTimeoutMs ?? (() => idleTimeoutToMs(getIdleTimeout()))
+  const deferMs = options.deferMs ?? DEFAULT_DEFER_MS
+
+  let timer: ReturnType<typeof setTimeout> | null = null
+  let started = false
+
+  function clear(): void {
+    if (timer !== null) {
+      clearTimeout(timer)
+      timer = null
+    }
+  }
+
+  function fire(): void {
+    timer = null
+    // Never interrupt an in-flight transaction — reschedule and check again.
+    if (options.shouldDefer?.()) {
+      timer = setTimeout(fire, deferMs)
+      return
+    }
+    options.onLock()
+  }
+
+  function reset(): void {
+    clear()
+    const ms = getTimeoutMs()
+    if (ms === null || ms <= 0) return // 'never' → auto-lock disabled
+    timer = setTimeout(fire, ms)
+  }
+
+  function start(): void {
+    if (started || typeof window === 'undefined') return
+    started = true
+    ACTIVITY_EVENTS.forEach((event) => window.addEventListener(event, reset, { passive: true }))
+    // Acceptance criterion: a visibility change resets the idle timer.
+    document.addEventListener('visibilitychange', reset)
+    window.addEventListener(IDLE_TIMEOUT_CHANGED_EVENT, reset)
+    reset()
+  }
+
+  function stop(): void {
+    if (!started) return
+    started = false
+    clear()
+    ACTIVITY_EVENTS.forEach((event) => window.removeEventListener(event, reset))
+    document.removeEventListener('visibilitychange', reset)
+    window.removeEventListener(IDLE_TIMEOUT_CHANGED_EVENT, reset)
+  }
+
+  return { start, stop, reset }
+}


### PR DESCRIPTION
## Summary

Implements **#351 — Inactive-session auto-lock**: after N minutes idle, the wallet clears in-memory session state and re-prompts the passkey before any further action. The timeout is user-configurable.

## What changed
- **`lib/idle-lock.ts`** (new) — a framework-agnostic idle watcher + the timeout config.
  - Listens for activity (`mousemove` / `keydown` / `touchstart` / `click` / `scroll`) **and** `visibilitychange`; any of them resets the countdown.
  - Timeout options **5 / 15 / 30 minutes, or never**, persisted in `localStorage`; `never` disables auto-lock.
  - Locking is deferred while a transaction is in flight (`txActive`), and a setting change applies immediately (a config-changed event re-arms live watchers).
- **`hooks/useInactivityLock.ts`** — refactored to delegate to the watcher. Same name/signature, so all 12 call sites are untouched; on lock it still `sessionStorage.clear()` + routes to `/lock`, which requires a fresh WebAuthn assertion.
- **`app/settings/security/page.tsx`** (new) — the timeout picker (5/15/30/never), linked from a new "Security & Lock" entry in the settings index. The lock screen copy no longer hardcodes "5 minutes".

## Acceptance criteria
- ✅ **Configurable timeout (5 / 15 / 30 / never)** — Settings → Security
- ✅ **Locks after idle** — watcher fires `onLock` after the timeout
- ✅ **Visibility-change resets the timer** — `visibilitychange` is a reset trigger

## Verification
- `npm run typecheck` — clean
- `npm test` (Jest/jsdom) — `lib/__tests__/idle-lock.test.ts`, **11/11 passing** (config round-trips, lock-after-idle, activity reset, visibility reset, never-disables, defer, live reconfigure, teardown)
- `npm run build` — succeeds; `/settings/security` route generated

Closes #351
