### PR TITLE
feat(elements): add drop-in <veil-button> web component

### DIFF
--- a/examples/elements/index.html
+++ b/examples/elements/index.html
@@ -1,0 +1,80 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Veil — Web Component example</title>
+    <style>
+      :root { color-scheme: dark; }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+        background: #0a0a0f;
+        color: #e5e7eb;
+      }
+      .card {
+        width: 100%;
+        max-width: 28rem;
+        border: 1px solid #1f2937;
+        background: #111827;
+        border-radius: 1rem;
+        padding: 1.5rem;
+      }
+      h1 { font-size: 1.4rem; margin: 0 0 0.25rem; }
+      p.muted { color: #9ca3af; font-size: 0.85rem; margin-top: 0; }
+      #result {
+        margin-top: 1.25rem;
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+        font-size: 0.8rem;
+        word-break: break-all;
+        min-height: 1.2rem;
+      }
+      .ok { color: #86efac; }
+      .err { color: #fca5a5; }
+    </style>
+  </head>
+  <body>
+    <div class="card">
+      <h1>Veil Web Component</h1>
+      <p class="muted">A drop-in <code>&lt;veil-button&gt;</code> on a plain HTML page — no build step for this site.</p>
+
+      <!--
+        factory-address is optional for the demo: registration runs and computes
+        an address from it. Paste your deployed Veil factory contract id to get a
+        real wallet address.
+      -->
+      <veil-button
+        network="testnet"
+        factory-address=""
+        username="demo-user"
+        label="Create wallet with passkey"
+      ></veil-button>
+
+      <div id="result"></div>
+    </div>
+
+    <!--
+      The bundled element. Build it first:
+        cd ../../sdk && npm install && npm run build
+        cd elements && npm install && npm run build
+      That produces sdk/elements/dist/veil-button.js, referenced below.
+    -->
+    <script type="module" src="../../sdk/elements/dist/veil-button.js"></script>
+
+    <script>
+      const result = document.getElementById('result')
+      document.addEventListener('veil:success', (e) => {
+        result.className = 'ok'
+        result.textContent = '✓ Wallet created: ' + e.detail.walletAddress
+      })
+      document.addEventListener('veil:error', (e) => {
+        result.className = 'err'
+        result.textContent = '✗ ' + e.detail.error
+      })
+    </script>
+  </body>
+</html>

--- a/sdk/elements/.gitignore
+++ b/sdk/elements/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/sdk/elements/README.md
+++ b/sdk/elements/README.md
@@ -1,0 +1,63 @@
+# Veil Elements — `<veil-button>`
+
+A drop-in [custom element](https://developer.mozilla.org/en-US/docs/Web/API/Web_components)
+that wraps the Invisible Wallet SDK. It works on any HTML page — including
+no-build static sites — once the bundled script is loaded. No framework
+required; it's a plain Web Component (vanilla, no Lit).
+
+## Build
+
+The element bundles the SDK into a single browser-loadable ESM file:
+
+```bash
+# from the repo root
+cd sdk && npm install && npm run build   # build the SDK first
+cd elements && npm install && npm run build
+# → produces sdk/elements/dist/veil-button.js
+```
+
+## Usage
+
+```html
+<veil-button network="testnet" factory-address="C..." label="Create wallet"></veil-button>
+<script type="module" src="./veil-button.js"></script>
+
+<script>
+  document.addEventListener('veil:success', (e) => {
+    console.log('wallet address', e.detail.walletAddress)
+  })
+  document.addEventListener('veil:error', (e) => {
+    console.error(e.detail.error)
+  })
+</script>
+```
+
+A complete page lives in [`examples/elements/index.html`](../../examples/elements/index.html).
+
+## Attributes
+
+| Attribute | Default | Description |
+|---|---|---|
+| `network` | `testnet` | `testnet` or `mainnet`; selects the network passphrase. |
+| `factory-address` | _(empty)_ | Veil factory contract id (`C…`). Required to compute a real wallet address; registration still runs without it. |
+| `rpc-url` | network default | Soroban RPC URL. |
+| `username` | _(none)_ | Optional passkey username / display name. |
+| `label` | `Create wallet with passkey` | Button text. |
+| `disabled` | _(absent)_ | Present to disable the button. |
+
+## Events
+
+Both events bubble and cross the shadow boundary, so you can listen on `document`.
+
+| Event | `detail` | When |
+|---|---|---|
+| `veil:success` | `{ walletAddress: string, publicKeyHex: string }` | A passkey was created and the wallet address computed. |
+| `veil:error` | `{ error: string }` | Registration failed or was cancelled. |
+
+## Notes
+
+- WebAuthn requires a secure context — serve over `https://` or `http://localhost`.
+- The button performs passkey **registration** (creates the credential and
+  computes the address). Deploying the contract on-chain needs a funded
+  fee-payer and is out of scope for a single drop-in button — see the
+  framework examples (`examples/nextjs`, `examples/nuxt`, …) for the full flow.

--- a/sdk/elements/package-lock.json
+++ b/sdk/elements/package-lock.json
@@ -1,0 +1,549 @@
+{
+  "name": "veil-elements",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "veil-elements",
+      "version": "0.1.0",
+      "dependencies": {
+        "invisible-wallet-sdk": "file:.."
+      },
+      "devDependencies": {
+        "esbuild": "^0.24.0",
+        "typescript": "^5.4.0"
+      }
+    },
+    "..": {
+      "name": "invisible-wallet-sdk",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@stellar/stellar-sdk": "^14.6.1"
+      },
+      "devDependencies": {
+        "@size-limit/preset-small-lib": "^12.1.0",
+        "@stryker-mutator/core": "^8.7.0",
+        "@stryker-mutator/jest-runner": "^8.7.0",
+        "@stryker-mutator/typescript-checker": "^8.7.0",
+        "@tanstack/react-query": "^5.0.0",
+        "@testing-library/react": "^16.0.0",
+        "@types/jest": "^29.0.0",
+        "@types/node": "^20.0.0",
+        "@types/react": "^18.0.0",
+        "@types/react-dom": "^18.0.0",
+        "fast-check": "^4.8.0",
+        "jest": "^29.7.0",
+        "jest-environment-jsdom": "^29.7.0",
+        "react": "^18.3.0",
+        "react-dom": "^18.3.0",
+        "size-limit": "^12.1.0",
+        "ts-jest": "^29.2.0",
+        "typescript": "^5.0.0"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.0.0",
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0",
+        "react-native": ">=0.72.0",
+        "react-native-passkey": ">=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "react-native-passkey": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.2.tgz",
+      "integrity": "sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.24.2.tgz",
+      "integrity": "sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.24.2.tgz",
+      "integrity": "sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.24.2.tgz",
+      "integrity": "sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.24.2.tgz",
+      "integrity": "sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.24.2.tgz",
+      "integrity": "sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.24.2.tgz",
+      "integrity": "sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.24.2.tgz",
+      "integrity": "sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.24.2.tgz",
+      "integrity": "sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.24.2.tgz",
+      "integrity": "sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.24.2.tgz",
+      "integrity": "sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.24.2.tgz",
+      "integrity": "sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.24.2.tgz",
+      "integrity": "sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.24.2.tgz",
+      "integrity": "sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.24.2.tgz",
+      "integrity": "sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.24.2.tgz",
+      "integrity": "sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.24.2.tgz",
+      "integrity": "sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.24.2.tgz",
+      "integrity": "sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.24.2.tgz",
+      "integrity": "sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.24.2.tgz",
+      "integrity": "sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.24.2.tgz",
+      "integrity": "sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.24.2.tgz",
+      "integrity": "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.2.tgz",
+      "integrity": "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.24.2",
+        "@esbuild/android-arm": "0.24.2",
+        "@esbuild/android-arm64": "0.24.2",
+        "@esbuild/android-x64": "0.24.2",
+        "@esbuild/darwin-arm64": "0.24.2",
+        "@esbuild/darwin-x64": "0.24.2",
+        "@esbuild/freebsd-arm64": "0.24.2",
+        "@esbuild/freebsd-x64": "0.24.2",
+        "@esbuild/linux-arm": "0.24.2",
+        "@esbuild/linux-arm64": "0.24.2",
+        "@esbuild/linux-ia32": "0.24.2",
+        "@esbuild/linux-loong64": "0.24.2",
+        "@esbuild/linux-mips64el": "0.24.2",
+        "@esbuild/linux-ppc64": "0.24.2",
+        "@esbuild/linux-riscv64": "0.24.2",
+        "@esbuild/linux-s390x": "0.24.2",
+        "@esbuild/linux-x64": "0.24.2",
+        "@esbuild/netbsd-arm64": "0.24.2",
+        "@esbuild/netbsd-x64": "0.24.2",
+        "@esbuild/openbsd-arm64": "0.24.2",
+        "@esbuild/openbsd-x64": "0.24.2",
+        "@esbuild/sunos-x64": "0.24.2",
+        "@esbuild/win32-arm64": "0.24.2",
+        "@esbuild/win32-ia32": "0.24.2",
+        "@esbuild/win32-x64": "0.24.2"
+      }
+    },
+    "node_modules/invisible-wallet-sdk": {
+      "resolved": "..",
+      "link": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/sdk/elements/package.json
+++ b/sdk/elements/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "veil-elements",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Drop-in Web Components wrapping the Invisible Wallet SDK",
+  "type": "module",
+  "main": "dist/veil-button.js",
+  "scripts": {
+    "build": "esbuild src/veil-button.ts --bundle --format=esm --platform=browser --target=es2020 --minify --outfile=dist/veil-button.js",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "invisible-wallet-sdk": "file:.."
+  },
+  "devDependencies": {
+    "esbuild": "^0.24.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/sdk/elements/src/veil-button.ts
+++ b/sdk/elements/src/veil-button.ts
@@ -1,0 +1,134 @@
+import { createInvisibleWallet, type WalletConfig } from 'invisible-wallet-sdk/vanilla'
+
+/**
+ * <veil-button> — a drop-in custom element that wraps the Invisible Wallet SDK.
+ *
+ * On click it creates a passkey-backed wallet (WebAuthn) and computes its
+ * Stellar contract address, then emits a `veil:success` (or `veil:error`)
+ * event. It works on any HTML page, including no-build static sites, once the
+ * bundled script is loaded.
+ *
+ * @example
+ * <veil-button
+ *   network="testnet"
+ *   factory-address="C..."
+ *   label="Create wallet"
+ * ></veil-button>
+ * <script type="module" src="./veil-button.js"></script>
+ *
+ * Attributes:
+ *   - network          "testnet" (default) | "mainnet"
+ *   - factory-address  the Veil factory contract id (C...). Required to compute
+ *                      a real wallet address; registration still runs without it.
+ *   - rpc-url          Soroban RPC URL. Defaults to the network's public RPC.
+ *   - username         optional passkey username/display name.
+ *   - label            button text. Defaults to "Create wallet with passkey".
+ *   - disabled         present to disable the button.
+ *
+ * Events (both bubble and cross shadow boundaries):
+ *   - veil:success     detail: { walletAddress: string; publicKeyHex: string }
+ *   - veil:error       detail: { error: string }
+ */
+
+const NETWORK_PASSPHRASES: Record<string, string> = {
+  testnet: 'Test SDF Network ; September 2015',
+  mainnet: 'Public Global Stellar Network ; September 2015',
+}
+
+const DEFAULT_RPC: Record<string, string> = {
+  testnet: 'https://soroban-testnet.stellar.org',
+  mainnet: 'https://mainnet.sorobanrpc.com',
+}
+
+function toHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('')
+}
+
+export class VeilButton extends HTMLElement {
+  static get observedAttributes() {
+    return ['label', 'disabled']
+  }
+
+  private button: HTMLButtonElement
+  private busy = false
+
+  constructor() {
+    super()
+    const root = this.attachShadow({ mode: 'open' })
+    const style = document.createElement('style')
+    style.textContent = `
+      :host { display: inline-block; font-family: inherit; }
+      button {
+        font: inherit;
+        font-weight: 600;
+        cursor: pointer;
+        padding: 0.6rem 1.1rem;
+        border-radius: 0.5rem;
+        border: 1px solid #4338ca;
+        background: #4f46e5;
+        color: #fff;
+        transition: opacity 0.15s, background 0.15s;
+      }
+      button:hover:not(:disabled) { background: #4338ca; }
+      button:disabled { opacity: 0.6; cursor: default; }
+    `
+    this.button = document.createElement('button')
+    this.button.type = 'button'
+    this.button.addEventListener('click', () => void this.handleClick())
+    root.append(style, this.button)
+    this.render()
+  }
+
+  connectedCallback() {
+    this.render()
+  }
+
+  attributeChangedCallback() {
+    this.render()
+  }
+
+  private get label(): string {
+    return this.getAttribute('label') || 'Create wallet with passkey'
+  }
+
+  private render() {
+    this.button.textContent = this.busy ? 'Creating…' : this.label
+    this.button.disabled = this.busy || this.hasAttribute('disabled')
+  }
+
+  private walletConfig(): WalletConfig {
+    const network = (this.getAttribute('network') || 'testnet').toLowerCase()
+    const networkPassphrase = NETWORK_PASSPHRASES[network] || NETWORK_PASSPHRASES.testnet
+    return {
+      factoryAddress: this.getAttribute('factory-address') || '',
+      rpcUrl: this.getAttribute('rpc-url') || DEFAULT_RPC[network] || DEFAULT_RPC.testnet,
+      networkPassphrase,
+    }
+  }
+
+  private emit(type: 'veil:success' | 'veil:error', detail: Record<string, unknown>) {
+    this.dispatchEvent(new CustomEvent(type, { detail, bubbles: true, composed: true }))
+  }
+
+  private async handleClick() {
+    if (this.busy) return
+    this.busy = true
+    this.render()
+    try {
+      const wallet = createInvisibleWallet(this.walletConfig())
+      const username = this.getAttribute('username') || undefined
+      const { walletAddress, publicKeyBytes } = await wallet.register(username)
+      this.emit('veil:success', { walletAddress, publicKeyHex: toHex(publicKeyBytes) })
+    } catch (err) {
+      this.emit('veil:error', { error: err instanceof Error ? err.message : String(err) })
+    } finally {
+      this.busy = false
+      this.render()
+    }
+  }
+}
+
+// Self-register the element when this module loads (idempotent).
+if (typeof customElements !== 'undefined' && !customElements.get('veil-button')) {
+  customElements.define('veil-button', VeilButton)
+}

--- a/sdk/elements/tsconfig.json
+++ b/sdk/elements/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": []
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

Adds a drop-in **Web Component** that wraps the vanilla Invisible Wallet SDK and emits success/error events, plus a plain-HTML example (#313).

## Key files

- `sdk/elements/src/veil-button.ts` (new) — `<veil-button>`, a vanilla custom element (shadow DOM, self-registering; no Lit/framework). On click it creates a passkey wallet and computes its address, then dispatches events.
- `examples/elements/index.html` (new) — a no-build static page using the element and listening for its events.
- `sdk/elements/` build setup (esbuild → one bundled ESM file) + README.

## Attributes

| Attribute | Default | Description |
|---|---|---|
| `network` | `testnet` | `testnet` / `mainnet` |
| `factory-address` | _(empty)_ | Veil factory contract id (`C…`) |
| `rpc-url` | network default | Soroban RPC URL |
| `username` | _(none)_ | Optional passkey username |
| `label` | `Create wallet with passkey` | Button text |
| `disabled` | _(absent)_ | Disables the button |

## Events (bubble + composed, so you can listen on `document`)

| Event | `detail` |
|---|---|
| `veil:success` | `{ walletAddress, publicKeyHex }` |
| `veil:error` | `{ error }` |

## Verification — acceptance criteria

- **Works on a plain HTML page:** `tsc` typecheck passes; `esbuild` bundles `src/veil-button.ts` into a single browser ESM file. Served the repo statically → `examples/elements/index.html` returns 200, the bundle returns 200 and contains `customElements.define`, `veil-button`, `veil:success`, `veil:error`. The element self-registers and renders its button; the example wires both events.
- **Documented attributes & events:** in `sdk/elements/README.md` and inline JSDoc.

## Notes

- The element is vanilla (no Lit) to keep it dependency-free for no-build sites. The build inlines the SDK (which bundles `@stellar/stellar-sdk`), so the output is large but fully self-contained; `dist/` is gitignored and produced by `npm run build` (consistent with the other examples requiring the SDK to be built first).
- WebAuthn needs a secure context (`localhost`/`https`). The button performs passkey **registration**; on-chain deploy needs a funded fee-payer and is left to the framework examples.

Closes #313