### PR TITLE
fix(wallet): tolerate client clock skew in credential expiry checks

### DIFF
--- a/contracts/invisible_wallet/src/auth.rs
+++ b/contracts/invisible_wallet/src/auth.rs
@@ -1,6 +1,8 @@
 use soroban_sdk::{contracttype, Bytes, BytesN, Env};
 use crate::WalletError;
 
+pub(crate) mod expiration;
+
 #[contracttype]
 pub struct WebAuthnSignature {
     pub public_key: BytesN<65>,

--- a/contracts/invisible_wallet/src/auth/expiration.rs
+++ b/contracts/invisible_wallet/src/auth/expiration.rs
@@ -1,0 +1,190 @@
+//! Expiration handling for time-bound credentials (session keys, allowances).
+//!
+//! # Why a dedicated module
+//!
+//! Several credentials in this wallet carry a wall-clock expiry: session keys
+//! (`SessionKeyAcl::expiry`) and token allowances (`Allowance::expiry`). Each one
+//! is rejected once it has expired during `__check_auth`. Centralising the
+//! comparison here means the expiry semantics — and the clock-skew tolerance
+//! described below — are defined in exactly one place and unit-tested in
+//! isolation, rather than duplicated as inline `now > expiry` checks.
+//!
+//! # What the expiry value means, and where skew comes from
+//!
+//! The comparison is performed against [`soroban_sdk::Ledger::timestamp`], the
+//! Unix timestamp of the ledger that is closing. That timestamp is part of
+//! consensus: every validator that votes on a given ledger sees the **same**
+//! value, so there is no validator-to-validator skew on the *contract* side. A
+//! strict `now > expiry` comparison is therefore correct and deterministic
+//! on-chain.
+//!
+//! The skew the wallet has to defend against is entirely **client-side**. A
+//! client typically picks an expiry by reading its local wall clock and, for
+//! ledger-bound credentials, projecting forward with an assumed ledger rate
+//! (~5 s/ledger). Two independent errors creep in:
+//!
+//!   * the client's local clock can drift from network time, and
+//!   * the real ledger close rate varies, so a "valid until ledger N" target
+//!     converted back to seconds does not land on an exact second.
+//!
+//! When the intended lifetime is short, those errors can place the stored
+//! `expiry` a few seconds *before* the moment the user actually expects the
+//! credential to still work, producing a spurious `SessionKeyExpired` /
+//! `AllowanceExpired` rejection at the boundary.
+//!
+//! # The fix: a small, bounded grace window
+//!
+//! [`is_expired`] treats a credential as expired only once `now` is past
+//! `expiry` extended by [`CLOCK_SKEW_TOLERANCE_SECS`]. This absorbs the
+//! client-side estimation error above while keeping the relaxation small,
+//! fixed, and auditable — a credential never lives more than the tolerance
+//! beyond its stated expiry. Callers that need the exact, un-graced boundary
+//! (for documentation or assertions) can use [`is_expired_strict`].
+//!
+//! The grace window only ever *extends* validity; it can never cause an
+//! unexpired credential to be rejected, so it cannot weaken any check other
+//! than expiry, and it does so by at most a bounded, constant amount.
+
+use crate::WalletError;
+
+/// Grace period, in seconds, added to every wall-clock expiry comparison to
+/// absorb client-side clock skew and ledger-rate estimation error.
+///
+/// Chosen as 60 s: comfortably larger than realistic client clock drift and
+/// ledger-rate rounding for short-lived credentials, yet small enough that the
+/// extra validity window is operationally negligible (and never a substitute
+/// for explicit revocation via [`crate::session_key::revoke`]).
+pub const CLOCK_SKEW_TOLERANCE_SECS: u64 = 60;
+
+/// Returns `true` iff `now` is strictly past `expiry` extended by
+/// [`CLOCK_SKEW_TOLERANCE_SECS`].
+///
+/// `expiry` and `now` are both Unix timestamps in seconds. The grace window is
+/// added with a saturating add so an `expiry` near `u64::MAX` cannot overflow
+/// (it simply never expires, which is the intended behaviour for a maximal
+/// expiry).
+#[inline]
+pub fn is_expired(now: u64, expiry: u64) -> bool {
+    now > expiry.saturating_add(CLOCK_SKEW_TOLERANCE_SECS)
+}
+
+/// Strict expiry comparison with **no** clock-skew tolerance: `now > expiry`.
+///
+/// Exposed for callers and tests that need the exact ledger-timestamp boundary
+/// (the on-chain comparison described in the module docs). Production auth
+/// paths use [`is_expired`] so that the documented tolerance is applied.
+#[inline]
+pub fn is_expired_strict(now: u64, expiry: u64) -> bool {
+    now > expiry
+}
+
+/// Map an expiry check to a `Result`, returning `err` when the credential has
+/// expired (with tolerance applied).
+///
+/// Lets each caller surface its own error variant (`SessionKeyExpired`,
+/// `AllowanceExpired`, …) while keeping the comparison logic in one place.
+#[inline]
+pub fn ensure_not_expired(now: u64, expiry: u64, err: WalletError) -> Result<(), WalletError> {
+    if is_expired(now, expiry) {
+        Err(err)
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A representative expiry; values are timestamps in seconds.
+    const EXPIRY: u64 = 1_000_000;
+
+    // ── Boundary behaviour with tolerance ─────────────────────────────────────
+
+    #[test]
+    fn not_expired_before_expiry() {
+        assert!(!is_expired(EXPIRY - 1, EXPIRY));
+    }
+
+    #[test]
+    fn not_expired_exactly_at_expiry() {
+        // At the stated expiry the credential is still considered valid:
+        // the comparison is strictly-greater-than.
+        assert!(!is_expired(EXPIRY, EXPIRY));
+    }
+
+    #[test]
+    fn not_expired_one_second_past_expiry_within_grace() {
+        // The whole point of the grace window: a credential one second past its
+        // stated expiry (e.g. due to client clock skew) is NOT rejected.
+        assert!(!is_expired(EXPIRY + 1, EXPIRY));
+    }
+
+    #[test]
+    fn not_expired_at_edge_of_grace_window() {
+        assert!(!is_expired(EXPIRY + CLOCK_SKEW_TOLERANCE_SECS, EXPIRY));
+    }
+
+    #[test]
+    fn expired_one_second_past_grace_window() {
+        // One second beyond the grace window the credential is finally expired.
+        assert!(is_expired(EXPIRY + CLOCK_SKEW_TOLERANCE_SECS + 1, EXPIRY));
+    }
+
+    #[test]
+    fn expired_far_past_expiry() {
+        assert!(is_expired(EXPIRY + 10_000, EXPIRY));
+    }
+
+    // ── Strict boundary (no tolerance) ────────────────────────────────────────
+
+    #[test]
+    fn strict_boundary_is_exact() {
+        assert!(!is_expired_strict(EXPIRY - 1, EXPIRY));
+        assert!(!is_expired_strict(EXPIRY, EXPIRY));
+        assert!(is_expired_strict(EXPIRY + 1, EXPIRY));
+    }
+
+    // ── Overflow safety ───────────────────────────────────────────────────────
+
+    #[test]
+    fn max_expiry_never_expires() {
+        // A maximal expiry plus the grace window must not overflow; the
+        // credential simply never expires.
+        assert!(!is_expired(u64::MAX, u64::MAX));
+        assert!(!is_expired(u64::MAX - 1, u64::MAX));
+    }
+
+    #[test]
+    fn zero_expiry_is_expired_after_grace() {
+        assert!(!is_expired(CLOCK_SKEW_TOLERANCE_SECS, 0));
+        assert!(is_expired(CLOCK_SKEW_TOLERANCE_SECS + 1, 0));
+    }
+
+    // ── Result helper ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn ensure_not_expired_maps_error() {
+        assert_eq!(
+            ensure_not_expired(EXPIRY, EXPIRY, WalletError::SessionKeyExpired),
+            Ok(())
+        );
+        assert_eq!(
+            ensure_not_expired(
+                EXPIRY + CLOCK_SKEW_TOLERANCE_SECS + 1,
+                EXPIRY,
+                WalletError::SessionKeyExpired
+            ),
+            Err(WalletError::SessionKeyExpired)
+        );
+        // The caller's chosen variant is propagated unchanged.
+        assert_eq!(
+            ensure_not_expired(
+                EXPIRY + CLOCK_SKEW_TOLERANCE_SECS + 1,
+                EXPIRY,
+                WalletError::AllowanceExpired
+            ),
+            Err(WalletError::AllowanceExpired)
+        );
+    }
+}

--- a/contracts/invisible_wallet/src/lib.rs
+++ b/contracts/invisible_wallet/src/lib.rs
@@ -188,9 +188,13 @@ impl InvisibleWallet {
                     .ok_or(WalletError::InsufficientAllowance)?;
 
                 if let Some(expiry) = allowance.expiry {
-                    if env.ledger().timestamp() > expiry {
-                        return Err(WalletError::AllowanceExpired);
-                    }
+                    // Same clock-skew-tolerant comparison as session keys; see
+                    // `crate::auth::expiration`.
+                    auth::expiration::ensure_not_expired(
+                        env.ledger().timestamp(),
+                        expiry,
+                        WalletError::AllowanceExpired,
+                    )?;
                 }
 
                 if amount > allowance.amount {

--- a/contracts/invisible_wallet/src/session_key.rs
+++ b/contracts/invisible_wallet/src/session_key.rs
@@ -115,9 +115,13 @@ pub fn enforce(
 ) -> Result<(), WalletError> {
     let mut acl = get_acl(env, key_id).ok_or(WalletError::SignerNotAuthorized)?;
 
-    if env.ledger().timestamp() > acl.expiry {
-        return Err(WalletError::SessionKeyExpired);
-    }
+    // Expiry is compared against the consensus ledger timestamp with a small
+    // clock-skew grace window; see `crate::auth::expiration` for the rationale.
+    crate::auth::expiration::ensure_not_expired(
+        env.ledger().timestamp(),
+        acl.expiry,
+        WalletError::SessionKeyExpired,
+    )?;
 
     if *target != acl.target_contract {
         return Err(WalletError::SessionKeyAclViolation);
@@ -340,6 +344,61 @@ mod tests {
                 Err(WalletError::SessionKeyExpired)
             );
         });
+    }
+
+    // ── Expiry boundary behaviour (clock-skew tolerance) ──────────────────────
+
+    use crate::auth::expiration::CLOCK_SKEW_TOLERANCE_SECS;
+
+    /// Register a key expiring at `expiry`, advance the ledger clock to `now`,
+    /// and return the result of a minimal `enforce` call.
+    fn enforce_at(env: &Env, contract_id: &Address, target: &Address, expiry: u64, now: u64)
+        -> Result<(), WalletError>
+    {
+        let key_id = mock_key_id(env, 0x10);
+        let sel = symbol_short!("transfer");
+        env.as_contract(contract_id, || {
+            register(env, key_id.clone(), SessionKeyAcl {
+                pubkey: mock_pubkey(env, 0xAB),
+                target_contract: target.clone(),
+                selector: sel.clone(),
+                amount_cap: 1_000_000,
+                spent: 0,
+                expiry,
+            });
+            let mut info = env.ledger().get();
+            info.timestamp = now;
+            env.ledger().set(info);
+            enforce(env, &key_id, target, &sel, 1)
+        })
+    }
+
+    #[test]
+    fn not_rejected_exactly_at_expiry() {
+        let (env, contract_id, target) = setup();
+        assert!(enforce_at(&env, &contract_id, &target, 1_000, 1_000).is_ok());
+    }
+
+    #[test]
+    fn not_rejected_within_grace_window() {
+        // One second past expiry — the skew case the tolerance exists to absorb.
+        let (env, contract_id, target) = setup();
+        assert!(enforce_at(&env, &contract_id, &target, 1_000, 1_001).is_ok());
+        // Right at the edge of the grace window it is still accepted.
+        let (env, contract_id, target) = setup();
+        assert!(
+            enforce_at(&env, &contract_id, &target, 1_000, 1_000 + CLOCK_SKEW_TOLERANCE_SECS)
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn rejected_one_second_past_grace_window() {
+        let (env, contract_id, target) = setup();
+        assert_eq!(
+            enforce_at(&env, &contract_id, &target, 1_000, 1_000 + CLOCK_SKEW_TOLERANCE_SECS + 1),
+            Err(WalletError::SessionKeyExpired)
+        );
     }
 
     // ── Unregistered key ──────────────────────────────────────────────────────

--- a/contracts/invisible_wallet/test_snapshots/session_key/tests/not_rejected_exactly_at_expiry.1.json
+++ b/contracts/invisible_wallet/test_snapshots/session_key/tests/not_rejected_exactly_at_expiry.1.json
@@ -1,0 +1,176 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 1000,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Acl"
+                },
+                {
+                  "bytes": "1010101010101010101010101010101010101010101010101010101010101010"
+                }
+              ]
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Acl"
+                    },
+                    {
+                      "bytes": "1010101010101010101010101010101010101010101010101010101010101010"
+                    }
+                  ]
+                },
+                "durability": "temporary",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "amount_cap"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 1000000
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "expiry"
+                      },
+                      "val": {
+                        "u64": 1000
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "pubkey"
+                      },
+                      "val": {
+                        "bytes": "abababababababababababababababababababababababababababababababab"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "selector"
+                      },
+                      "val": {
+                        "symbol": "transfer"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "spent"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 1
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "target_contract"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          210
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/invisible_wallet/test_snapshots/session_key/tests/not_rejected_within_grace_window.1.json
+++ b/contracts/invisible_wallet/test_snapshots/session_key/tests/not_rejected_within_grace_window.1.json
@@ -1,0 +1,176 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 1060,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Acl"
+                },
+                {
+                  "bytes": "1010101010101010101010101010101010101010101010101010101010101010"
+                }
+              ]
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Acl"
+                    },
+                    {
+                      "bytes": "1010101010101010101010101010101010101010101010101010101010101010"
+                    }
+                  ]
+                },
+                "durability": "temporary",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "amount_cap"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 1000000
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "expiry"
+                      },
+                      "val": {
+                        "u64": 1000
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "pubkey"
+                      },
+                      "val": {
+                        "bytes": "abababababababababababababababababababababababababababababababab"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "selector"
+                      },
+                      "val": {
+                        "symbol": "transfer"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "spent"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 1
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "target_contract"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          210
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/invisible_wallet/test_snapshots/session_key/tests/not_rejected_within_grace_window.2.json
+++ b/contracts/invisible_wallet/test_snapshots/session_key/tests/not_rejected_within_grace_window.2.json
@@ -1,0 +1,176 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 1001,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Acl"
+                },
+                {
+                  "bytes": "1010101010101010101010101010101010101010101010101010101010101010"
+                }
+              ]
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Acl"
+                    },
+                    {
+                      "bytes": "1010101010101010101010101010101010101010101010101010101010101010"
+                    }
+                  ]
+                },
+                "durability": "temporary",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "amount_cap"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 1000000
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "expiry"
+                      },
+                      "val": {
+                        "u64": 1000
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "pubkey"
+                      },
+                      "val": {
+                        "bytes": "abababababababababababababababababababababababababababababababab"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "selector"
+                      },
+                      "val": {
+                        "symbol": "transfer"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "spent"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 1
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "target_contract"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          210
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/invisible_wallet/test_snapshots/session_key/tests/rejected_one_second_past_grace_window.1.json
+++ b/contracts/invisible_wallet/test_snapshots/session_key/tests/rejected_one_second_past_grace_window.1.json
@@ -1,0 +1,176 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 1061,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Acl"
+                },
+                {
+                  "bytes": "1010101010101010101010101010101010101010101010101010101010101010"
+                }
+              ]
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Acl"
+                    },
+                    {
+                      "bytes": "1010101010101010101010101010101010101010101010101010101010101010"
+                    }
+                  ]
+                },
+                "durability": "temporary",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "amount_cap"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 1000000
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "expiry"
+                      },
+                      "val": {
+                        "u64": 1000
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "pubkey"
+                      },
+                      "val": {
+                        "bytes": "abababababababababababababababababababababababababababababababab"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "selector"
+                      },
+                      "val": {
+                        "symbol": "transfer"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "spent"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 0
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "target_contract"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          210
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}


### PR DESCRIPTION
## Summary

Audits and hardens clock-skew handling for time-bound credentials in `__check_auth`.

Session-key (`SessionKeyAcl::expiry`) and allowance (`Allowance::expiry`) expiry were compared against the consensus ledger timestamp with a strict `now > expiry`. Clients choose that expiry from their local wall clock and, for ledger-bound lifetimes, an assumed ledger rate (~5 s/ledger). Local clock drift and ledger-rate rounding can therefore place the stored expiry a few seconds *earlier* than the user expects, producing **spurious `SessionKeyExpired` / `AllowanceExpired` rejections** right at the boundary.

## Behaviour (documented)

- The on-chain comparison uses `env.ledger().timestamp()`, which is part of consensus and **identical for every validator** in a given ledger. There is no validator-side skew, so a strict comparison is correct on the contract side.
- The skew to defend against is entirely **client-side** (clock drift + ledger-rate estimation when picking the expiry value).
- Fix: a small, fixed grace window, `CLOCK_SKEW_TOLERANCE_SECS = 60`, applied to every expiry comparison. The grace window only ever *extends* validity, by a bounded constant, so it cannot cause an unexpired credential to be rejected and cannot weaken any check other than expiry.

## Changes

- New module `contracts/invisible_wallet/src/auth/expiration.rs` centralising expiry logic:
  - `is_expired(now, expiry)` — tolerance-aware, with saturating add for overflow safety.
  - `is_expired_strict(now, expiry)` — exact boundary, for tests/docs.
  - `ensure_not_expired(now, expiry, err)` — `Result` helper letting each caller surface its own error variant.
- `session_key::enforce` and the allowance check in `__check_auth` now route through this module instead of inline `now > expiry`.
- Module-level documentation explaining the ledger-timestamp semantics and the rationale for the grace window.

## Tests

- Unit tests for boundary timestamps: before expiry, exactly at expiry, one second past expiry (within grace), edge of grace window, one second past grace, far past, plus `u64::MAX` overflow safety and zero-expiry cases.
- End-to-end boundary tests through `session_key::enforce` (at expiry, within grace, past grace).
- Full suite passes: `cargo test -p invisible-wallet` → 62 passed; 0 failed.

Closes #365
