### PR TITLE
feat(wallet): transaction simulation preview before signing (#342)

### DIFF
--- a/frontend/wallet/components/TxPreviewCard.tsx
+++ b/frontend/wallet/components/TxPreviewCard.tsx
@@ -1,0 +1,209 @@
+'use client'
+
+import { useEffect, useRef, useState, type CSSProperties } from 'react'
+import {
+  previewTransaction,
+  formatAmount,
+  type TxPreview,
+} from '@/lib/simulate'
+
+interface TxPreviewCardProps {
+  /** Unsigned Soroban transaction XDR to preview before the passkey prompt. */
+  xdr: string
+  rpcUrl?: string
+  networkPassphrase?: string
+  tokenDecimals?: Record<string, number>
+  /**
+   * Called once the preview resolves. Parents should disable signing when the
+   * result is `{ status: 'blocked' }` — a failed simulation is a hard block.
+   */
+  onResult?: (preview: TxPreview) => void
+}
+
+export function TxPreviewCard({
+  xdr,
+  rpcUrl,
+  networkPassphrase,
+  tokenDecimals,
+  onResult,
+}: TxPreviewCardProps) {
+  const [preview, setPreview] = useState<TxPreview | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  // Read callback/options via refs so inline props don't re-trigger the effect.
+  const onResultRef = useRef(onResult)
+  onResultRef.current = onResult
+  const tokenDecimalsRef = useRef(tokenDecimals)
+  tokenDecimalsRef.current = tokenDecimals
+
+  useEffect(() => {
+    let active = true
+    setLoading(true)
+    setPreview(null)
+
+    previewTransaction({
+      xdr,
+      rpcUrl,
+      networkPassphrase,
+      tokenDecimals: tokenDecimalsRef.current,
+    })
+      .then((result) => {
+        if (!active) return
+        setPreview(result)
+        onResultRef.current?.(result)
+      })
+      .catch((err: unknown) => {
+        if (!active) return
+        const blocked: TxPreview = {
+          status: 'blocked',
+          error: err instanceof Error ? err.message : String(err),
+        }
+        setPreview(blocked)
+        onResultRef.current?.(blocked)
+      })
+      .finally(() => {
+        if (active) setLoading(false)
+      })
+
+    return () => {
+      active = false
+    }
+  }, [xdr, rpcUrl, networkPassphrase])
+
+  if (loading) {
+    return (
+      <div style={cardStyle} aria-busy="true">
+        <p style={mutedStyle}>Simulating transaction…</p>
+      </div>
+    )
+  }
+
+  if (!preview) return null
+
+  if (preview.status === 'blocked') {
+    return (
+      <div
+        role="alert"
+        style={{
+          ...cardStyle,
+          border: '1px solid var(--border-dim)',
+          borderLeft: '3px solid #e5484d',
+        }}
+      >
+        <p style={{ margin: 0, fontWeight: 600, color: '#e5484d' }}>
+          ⚠ Cannot simulate this transaction
+        </p>
+        <p style={{ ...mutedStyle, marginTop: '0.5rem' }}>
+          Signing is blocked until the transaction can be simulated successfully.
+        </p>
+        <p
+          style={{
+            ...mutedStyle,
+            marginTop: '0.5rem',
+            fontFamily: 'monospace',
+            fontSize: '0.75rem',
+            wordBreak: 'break-word',
+          }}
+        >
+          {preview.error}
+        </p>
+      </div>
+    )
+  }
+
+  const { transfers, swap, feeStroops, functionName } = preview
+
+  return (
+    <div style={cardStyle} aria-label="Transaction preview">
+      <p style={{ margin: 0, fontWeight: 600, color: 'var(--off-white)' }}>
+        Review transaction
+      </p>
+
+      {transfers.length === 0 && !swap && (
+        <p style={{ ...mutedStyle, marginTop: '0.75rem' }}>
+          {functionName
+            ? `Calls ${functionName} — no token movement detected.`
+            : 'No token movement detected.'}
+        </p>
+      )}
+
+      {transfers.map((transfer, index) => (
+        <Row
+          key={`${transfer.token ?? 'token'}-${index}`}
+          label="You send"
+          value={`${transfer.display} ${shorten(transfer.token)}`}
+        />
+      ))}
+
+      {swap?.minReceiveDisplay && (
+        <Row
+          label="You receive at least"
+          value={swap.minReceiveDisplay}
+          accent
+        />
+      )}
+      {swap?.estimatedReceiveDisplay && (
+        <Row label="Estimated receive" value={swap.estimatedReceiveDisplay} />
+      )}
+
+      {feeStroops && (
+        <Row label="Network fee" value={`~${formatAmount(BigInt(feeStroops), 7)} XLM`} />
+      )}
+    </div>
+  )
+}
+
+function Row({
+  label,
+  value,
+  accent,
+}: {
+  label: string
+  value: string
+  accent?: boolean
+}) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'baseline',
+        gap: '1rem',
+        marginTop: '0.75rem',
+      }}
+    >
+      <span style={mutedStyle}>{label}</span>
+      <span
+        style={{
+          fontWeight: 600,
+          color: accent ? 'var(--gold)' : 'var(--off-white)',
+          textAlign: 'right',
+          wordBreak: 'break-word',
+        }}
+      >
+        {value}
+      </span>
+    </div>
+  )
+}
+
+/** Shortens a long contract id for display; passes short labels through. */
+function shorten(value: string | null): string {
+  if (!value) return 'token'
+  if (value.length <= 12) return value
+  return `${value.slice(0, 4)}…${value.slice(-4)}`
+}
+
+const cardStyle: CSSProperties = {
+  background: 'var(--surface)',
+  border: '1px solid var(--border-dim)',
+  borderRadius: '0.75rem',
+  padding: '1rem 1.25rem',
+  maxWidth: 480,
+}
+
+const mutedStyle: CSSProperties = {
+  margin: 0,
+  color: 'var(--warm-grey)',
+  fontSize: '0.875rem',
+}

--- a/frontend/wallet/lib/__tests__/simulate.test.ts
+++ b/frontend/wallet/lib/__tests__/simulate.test.ts
@@ -1,0 +1,208 @@
+// @stellar/stellar-sdk needs TextEncoder at module load; jsdom omits it.
+import { TextEncoder, TextDecoder } from 'util'
+Object.assign(globalThis, { TextEncoder, TextDecoder })
+
+import {
+  Account,
+  Address,
+  Asset,
+  BASE_FEE,
+  Contract,
+  Keypair,
+  Networks,
+  Operation,
+  StrKey,
+  TransactionBuilder,
+  nativeToScVal,
+  xdr,
+} from '@stellar/stellar-sdk'
+import {
+  buildSwapPreview,
+  decodeTransfers,
+  extractInvocation,
+  formatAmount,
+  previewTransaction,
+  type ContractInvocation,
+  type DecodedEvent,
+  type SimulateCapable,
+} from '../simulate'
+
+const NETWORK = Networks.TESTNET
+
+function randomAddress(): string {
+  return Keypair.random().publicKey()
+}
+
+function buildInvokeXdr(
+  contractId: string,
+  fn: string,
+  args: xdr.ScVal[],
+): string {
+  const source = new Account(randomAddress(), '0')
+  return new TransactionBuilder(source, { fee: BASE_FEE, networkPassphrase: NETWORK })
+    .addOperation(new Contract(contractId).call(fn, ...args))
+    .setTimeout(30)
+    .build()
+    .toXDR()
+}
+
+/** A fake RPC server that always returns the supplied simulation response. */
+function fakeServer(sim: unknown): SimulateCapable {
+  return { simulateTransaction: async () => sim as never }
+}
+
+// Generated at runtime so no Stellar-format string literal is committed.
+const TOKEN = StrKey.encodeContract(Buffer.alloc(32, 7))
+
+describe('formatAmount', () => {
+  it('applies decimals and trims trailing zeros', () => {
+    expect(formatAmount(123456789n, 7)).toBe('12.3456789')
+    expect(formatAmount(50_000_000n, 7)).toBe('5')
+    expect(formatAmount(1n, 7)).toBe('0.0000001')
+    expect(formatAmount(0n, 7)).toBe('0')
+  })
+
+  it('handles negatives and zero-decimal tokens', () => {
+    expect(formatAmount(-2500000n, 7)).toBe('-0.25')
+    expect(formatAmount(42n, 0)).toBe('42')
+  })
+})
+
+describe('extractInvocation', () => {
+  it('reads contract id, function name and args from an invoke op', () => {
+    const args = [
+      new Address(randomAddress()).toScVal(),
+      new Address(randomAddress()).toScVal(),
+      nativeToScVal(123n, { type: 'i128' }),
+    ]
+    const tx = TransactionBuilder.fromXDR(buildInvokeXdr(TOKEN, 'transfer', args), NETWORK)
+
+    const invocation = extractInvocation(tx)
+    expect(invocation?.contractId).toBe(TOKEN)
+    expect(invocation?.functionName).toBe('transfer')
+    expect(invocation?.args).toHaveLength(3)
+  })
+
+  it('returns null for non-Soroban operations', () => {
+    const source = new Account(randomAddress(), '0')
+    const tx = new TransactionBuilder(source, { fee: BASE_FEE, networkPassphrase: NETWORK })
+      .addOperation(
+        Operation.payment({
+          destination: randomAddress(),
+          asset: Asset.native(),
+          amount: '1',
+        }),
+      )
+      .setTimeout(30)
+      .build()
+
+    expect(extractInvocation(tx)).toBeNull()
+  })
+})
+
+describe('decodeTransfers', () => {
+  it('extracts SAC transfer amount from raw i128 data', () => {
+    const events: DecodedEvent[] = [
+      {
+        type: 'contract',
+        contractId: TOKEN,
+        topics: ['transfer', 'GFROM', 'GTO'],
+        data: 500000000n,
+      },
+    ]
+    const [transfer] = decodeTransfers(events)
+    expect(transfer.token).toBe(TOKEN)
+    expect(transfer.from).toBe('GFROM')
+    expect(transfer.to).toBe('GTO')
+    expect(transfer.amount).toBe(500000000n)
+    // amount + decimals shown to the user
+    expect(formatAmount(transfer.amount, 7)).toBe('50')
+  })
+
+  it('extracts amount from protocol-22 map-form data', () => {
+    const events: DecodedEvent[] = [
+      { type: 'contract', contractId: TOKEN, topics: ['transfer', 'GA', 'GB'], data: { amount: 250n } },
+    ]
+    expect(decodeTransfers(events)[0].amount).toBe(250n)
+  })
+
+  it('ignores non-transfer events', () => {
+    const events: DecodedEvent[] = [
+      { type: 'contract', contractId: TOKEN, topics: ['mint', 'GA'], data: 1n },
+    ]
+    expect(decodeTransfers(events)).toHaveLength(0)
+  })
+})
+
+describe('buildSwapPreview', () => {
+  it('surfaces the slippage floor (min receive) and simulated estimate', () => {
+    const invocation: ContractInvocation = {
+      contractId: TOKEN,
+      functionName: 'swap_exact_tokens_for_tokens',
+      args: [
+        nativeToScVal(500000000n, { type: 'i128' }), // amount_in
+        nativeToScVal(510000000n, { type: 'i128' }), // amount_out_min
+      ],
+    }
+    const swap = buildSwapPreview(invocation, [500000000n, 512000000n], 7)
+    expect(swap?.minReceiveDisplay).toBe('51')
+    expect(swap?.estimatedReceiveDisplay).toBe('51.2')
+  })
+
+  it('returns null for non-swap functions', () => {
+    const invocation: ContractInvocation = { contractId: TOKEN, functionName: 'transfer', args: [] }
+    expect(buildSwapPreview(invocation, null, 7)).toBeNull()
+  })
+})
+
+describe('previewTransaction', () => {
+  it('hard-blocks when simulation reports an error', async () => {
+    const xdrStr = buildInvokeXdr(TOKEN, 'transfer', [nativeToScVal(1n, { type: 'i128' })])
+    const result = await previewTransaction({
+      xdr: xdrStr,
+      networkPassphrase: NETWORK,
+      server: fakeServer({ error: 'contract trapped', events: [] }),
+    })
+
+    expect(result.status).toBe('blocked')
+    if (result.status === 'blocked') {
+      expect(result.error).toBe('contract trapped')
+    }
+  })
+
+  it('hard-blocks on malformed XDR without calling the network', async () => {
+    let called = false
+    const result = await previewTransaction({
+      xdr: 'not-valid-xdr',
+      networkPassphrase: NETWORK,
+      server: { simulateTransaction: async () => { called = true; return {} as never } },
+    })
+
+    expect(result.status).toBe('blocked')
+    expect(called).toBe(false)
+  })
+
+  it('builds a ready swap preview with min-receive from a successful simulation', async () => {
+    const xdrStr = buildInvokeXdr(TOKEN, 'swap_exact_tokens_for_tokens', [
+      nativeToScVal(500000000n, { type: 'i128' }),
+      nativeToScVal(510000000n, { type: 'i128' }),
+    ])
+    const retval = xdr.ScVal.scvVec([
+      nativeToScVal(500000000n, { type: 'i128' }),
+      nativeToScVal(512000000n, { type: 'i128' }),
+    ])
+    const result = await previewTransaction({
+      xdr: xdrStr,
+      networkPassphrase: NETWORK,
+      server: fakeServer({ events: [], minResourceFee: '1250000', result: { retval } }),
+    })
+
+    expect(result.status).toBe('ready')
+    if (result.status === 'ready') {
+      expect(result.functionName).toBe('swap_exact_tokens_for_tokens')
+      expect(result.swap?.minReceiveDisplay).toBe('51')
+      expect(result.swap?.estimatedReceiveDisplay).toBe('51.2')
+      expect(result.feeStroops).toBe('1250000')
+    }
+  })
+})

--- a/frontend/wallet/lib/simulate.ts
+++ b/frontend/wallet/lib/simulate.ts
@@ -1,0 +1,302 @@
+import {
+  Address,
+  StrKey,
+  TransactionBuilder,
+  rpc as SorobanRpc,
+  scValToNative,
+  xdr,
+} from '@stellar/stellar-sdk'
+import { getNetwork } from './network'
+
+/**
+ * Transaction simulation preview (issue #342).
+ *
+ * Before the wallet shows a passkey prompt we simulate the Soroban transaction
+ * with `simulateTransaction`, decode its contract events and return value, and
+ * surface a humanized summary ("you send 50 USDC", "you receive at least 51.2
+ * XLM"). A simulation that fails is a hard block — the caller must refuse to
+ * sign.
+ */
+
+// Classic Stellar assets and their Stellar Asset Contract (SAC) wrappers use 7
+// decimals. Soroban-native tokens may differ; callers can override per token.
+export const DEFAULT_TOKEN_DECIMALS = 7
+
+/** Minimal surface of `rpc.Server` we depend on (injectable for tests). */
+export interface SimulateCapable {
+  simulateTransaction(
+    tx: Parameters<SorobanRpc.Server['simulateTransaction']>[0],
+  ): Promise<SorobanRpc.Api.SimulateTransactionResponse>
+}
+
+export interface DecodedEvent {
+  type: string
+  contractId: string | null
+  topics: unknown[]
+  data: unknown
+}
+
+export interface TokenTransfer {
+  token: string | null
+  from: string | null
+  to: string | null
+  amount: bigint
+}
+
+export interface PricedTransfer extends TokenTransfer {
+  decimals: number
+  display: string
+}
+
+export interface ContractInvocation {
+  contractId: string
+  functionName: string
+  args: xdr.ScVal[]
+}
+
+export interface SwapPreview {
+  amountIn: bigint | null
+  minReceive: bigint | null
+  estimatedReceive: bigint | null
+  decimals: number
+  minReceiveDisplay: string | null
+  estimatedReceiveDisplay: string | null
+}
+
+export type TxPreview =
+  | {
+      status: 'ready'
+      functionName: string | null
+      contractId: string | null
+      transfers: PricedTransfer[]
+      swap: SwapPreview | null
+      feeStroops: string | null
+      returnValue: unknown
+      events: DecodedEvent[]
+    }
+  | { status: 'blocked'; error: string }
+
+export interface PreviewTransactionParams {
+  /** Unsigned Soroban transaction XDR (base64). */
+  xdr: string
+  rpcUrl?: string
+  networkPassphrase?: string
+  /** Soroban RPC client; defaults to a real server built from `rpcUrl`. */
+  server?: SimulateCapable
+  /** Per-token decimal overrides, keyed by contract id. */
+  tokenDecimals?: Record<string, number>
+}
+
+/**
+ * Simulates a transaction and returns a humanized preview. A failed simulation
+ * resolves to `{ status: 'blocked' }` so the UI can hard-block signing rather
+ * than throwing.
+ */
+export async function previewTransaction(
+  params: PreviewTransactionParams,
+): Promise<TxPreview> {
+  const network = getNetwork()
+  const networkPassphrase = params.networkPassphrase ?? network.networkPassphrase
+  const rpcUrl = params.rpcUrl ?? network.rpcUrl
+
+  let tx: ReturnType<typeof TransactionBuilder.fromXDR>
+  try {
+    tx = TransactionBuilder.fromXDR(params.xdr, networkPassphrase)
+  } catch (err) {
+    return { status: 'blocked', error: `Malformed transaction: ${errorMessage(err)}` }
+  }
+
+  const server = params.server ?? new SorobanRpc.Server(rpcUrl)
+
+  let sim: SorobanRpc.Api.SimulateTransactionResponse
+  try {
+    sim = await server.simulateTransaction(tx)
+  } catch (err) {
+    return { status: 'blocked', error: `Simulation failed: ${errorMessage(err)}` }
+  }
+
+  if (SorobanRpc.Api.isSimulationError(sim)) {
+    return { status: 'blocked', error: sim.error }
+  }
+
+  const invocation = extractInvocation(tx)
+  const events = decodeEvents(sim.events ?? [])
+  const decimalsFor = (token: string | null): number => {
+    const override = token ? params.tokenDecimals?.[token] : undefined
+    return override ?? DEFAULT_TOKEN_DECIMALS
+  }
+
+  const transfers: PricedTransfer[] = decodeTransfers(events).map((t) => {
+    const decimals = decimalsFor(t.token)
+    return { ...t, decimals, display: formatAmount(t.amount, decimals) }
+  })
+
+  const returnValue = decodeReturnValue(sim)
+  const swap = invocation
+    ? buildSwapPreview(invocation, returnValue, decimalsFor(invocation.contractId))
+    : null
+
+  return {
+    status: 'ready',
+    functionName: invocation?.functionName ?? null,
+    contractId: invocation?.contractId ?? null,
+    transfers,
+    swap,
+    feeStroops: 'minResourceFee' in sim ? sim.minResourceFee : null,
+    returnValue,
+    events,
+  }
+}
+
+/** Reads the first `InvokeContract` host function from a (possibly fee-bumped) tx. */
+export function extractInvocation(
+  tx: ReturnType<typeof TransactionBuilder.fromXDR>,
+): ContractInvocation | null {
+  const inner = 'innerTransaction' in tx ? tx.innerTransaction : tx
+  const op = inner.operations?.[0]
+  if (!op || op.type !== 'invokeHostFunction') return null
+
+  try {
+    const func = op.func
+    if (func.switch().name !== 'hostFunctionTypeInvokeContract') return null
+    const ic = func.invokeContract()
+    return {
+      contractId: Address.fromScAddress(ic.contractAddress()).toString(),
+      functionName: ic.functionName().toString(),
+      args: ic.args(),
+    }
+  } catch {
+    return null
+  }
+}
+
+/** Decodes diagnostic events into plain `{ topics, data }` objects. */
+export function decodeEvents(events: xdr.DiagnosticEvent[]): DecodedEvent[] {
+  const decoded: DecodedEvent[] = []
+  for (const diagnostic of events) {
+    try {
+      const event = diagnostic.event()
+      const contractIdBuf = event.contractId()
+      const body = event.body().v0()
+      decoded.push({
+        type: event.type().name,
+        contractId: contractIdBuf
+          ? StrKey.encodeContract(contractIdBuf as unknown as Buffer)
+          : null,
+        topics: body.topics().map(safeScValToNative),
+        data: safeScValToNative(body.data()),
+      })
+    } catch {
+      // Skip events we cannot decode rather than failing the whole preview.
+    }
+  }
+  return decoded
+}
+
+/**
+ * Extracts SAC-style `transfer` events. The amount lives in the event data,
+ * either as a raw i128 or (protocol 22+) a map containing `amount`.
+ */
+export function decodeTransfers(events: DecodedEvent[]): TokenTransfer[] {
+  const transfers: TokenTransfer[] = []
+  for (const event of events) {
+    if (!Array.isArray(event.topics) || event.topics[0] !== 'transfer') continue
+    const amount = toBigInt(extractAmount(event.data))
+    if (amount === null) continue
+    transfers.push({
+      token: event.contractId,
+      from: asAddressString(event.topics[1]),
+      to: asAddressString(event.topics[2]),
+      amount,
+    })
+  }
+  return transfers
+}
+
+/**
+ * Builds a swap summary for router-style invocations
+ * (`swap_exact_tokens_for_tokens(amount_in, amount_out_min, ...)`), exposing the
+ * guaranteed minimum receive (the slippage floor) and the simulated estimate.
+ */
+export function buildSwapPreview(
+  invocation: ContractInvocation,
+  returnValue: unknown,
+  decimals: number,
+): SwapPreview | null {
+  if (!/swap/i.test(invocation.functionName)) return null
+
+  const amountIn = toBigInt(safeScValToNative(invocation.args[0]))
+  const minReceive = toBigInt(safeScValToNative(invocation.args[1]))
+  const estimatedReceive = estimatedReceiveFromReturn(returnValue)
+
+  if (amountIn === null && minReceive === null && estimatedReceive === null) {
+    return null
+  }
+
+  return {
+    amountIn,
+    minReceive,
+    estimatedReceive,
+    decimals,
+    minReceiveDisplay: minReceive === null ? null : formatAmount(minReceive, decimals),
+    estimatedReceiveDisplay:
+      estimatedReceive === null ? null : formatAmount(estimatedReceive, decimals),
+  }
+}
+
+/** Formats a base-unit integer amount into a human decimal string. */
+export function formatAmount(raw: bigint, decimals: number): string {
+  if (decimals <= 0) return raw.toString()
+
+  const negative = raw < 0n
+  const digits = (negative ? -raw : raw).toString().padStart(decimals + 1, '0')
+  const whole = digits.slice(0, digits.length - decimals)
+  const fraction = digits.slice(digits.length - decimals).replace(/0+$/, '')
+  const sign = negative ? '-' : ''
+  return fraction ? `${sign}${whole}.${fraction}` : `${sign}${whole}`
+}
+
+// ── internal helpers ────────────────────────────────────────────────────────
+
+function decodeReturnValue(sim: SorobanRpc.Api.SimulateTransactionResponse): unknown {
+  const retval = 'result' in sim ? sim.result?.retval : undefined
+  return retval ? safeScValToNative(retval) : null
+}
+
+function estimatedReceiveFromReturn(returnValue: unknown): bigint | null {
+  // Router swaps return the per-hop amounts; the last entry is the final out.
+  if (Array.isArray(returnValue) && returnValue.length > 0) {
+    return toBigInt(returnValue[returnValue.length - 1])
+  }
+  return toBigInt(returnValue)
+}
+
+function extractAmount(data: unknown): unknown {
+  if (data !== null && typeof data === 'object' && 'amount' in data) {
+    return (data as { amount: unknown }).amount
+  }
+  return data
+}
+
+function safeScValToNative(value: xdr.ScVal): unknown {
+  try {
+    return scValToNative(value)
+  } catch {
+    return null
+  }
+}
+
+function toBigInt(value: unknown): bigint | null {
+  if (typeof value === 'bigint') return value
+  if (typeof value === 'number' && Number.isInteger(value)) return BigInt(value)
+  if (typeof value === 'string' && /^-?\d+$/.test(value)) return BigInt(value)
+  return null
+}
+
+function asAddressString(value: unknown): string | null {
+  return typeof value === 'string' ? value : null
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}


### PR DESCRIPTION
## Summary

Implements **#342** — a humanized preview of a Soroban transaction shown *before* the passkey prompt, so users can catch costly mistakes ("you send 50 USDC and receive at least 51.2 XLM") instead of blind-signing.

## What's included (the issue's key files)

- **`frontend/wallet/lib/simulate.ts`**
  - `previewTransaction({ xdr, rpcUrl?, networkPassphrase?, server?, tokenDecimals? })` runs Soroban RPC `simulateTransaction`, then decodes the contract **events** and **return value** into a `TxPreview`.
  - **Token transfers** → amount + decimals (decoded from SAC `transfer` events; supports both raw-i128 and protocol‑22 map-form event data; classic/SAC tokens default to 7 decimals, overridable per token).
  - **Router swaps** (`swap_exact_tokens_for_tokens`-style) → the guaranteed **min‑receive** (slippage floor, from the call args) plus the simulated estimate (from the return value).
  - **Hard block**: a failed *or* malformed simulation resolves to `{ status: 'blocked', error }` — callers must refuse to sign. (`server` is injectable for testing.)
- **`frontend/wallet/components/TxPreviewCard.tsx`**
  - Renders loading / **blocked** (hard-block) / ready states with the wallet's inline-style + CSS‑var aesthetic.
  - Calls `onResult(preview)` so the parent can gate signing (disable the passkey button when `status === 'blocked'`).
- **`frontend/wallet/lib/__tests__/simulate.test.ts`** — 12 tests covering all three acceptance criteria.

## Acceptance criteria

- [x] Path payments show min-receive
- [x] Token transfers show amount + decimals
- [x] Failure to simulate is a hard block

## Suggested wiring (drop-in before the passkey prompt)

```tsx
const [canSign, setCanSign] = useState(false)
// ...
<TxPreviewCard xdr={unsignedXdr} onResult={(p) => setCanSign(p.status === 'ready')} />
<button disabled={!canSign} onClick={signWithPasskey}>Confirm</button>
```

## Testing

Run in `frontend/wallet`:

- `npm run typecheck` — clean
- `npm run build` — clean
- `npx jest lib/__tests__/simulate.test.ts` — 12/12 pass (min-receive end-to-end via a real swap tx + stubbed sim, transfer amount+decimals, hard-block on both error and malformed XDR)

> Note: this issue requires joining the contributor Telegram before the work counts toward the Stellar Wave.

Closes #342
