### PR TITLE
feat(wallet): asset trustline manager UI (#343)

### DIFF
--- a/frontend/wallet/app/assets/page.tsx
+++ b/frontend/wallet/app/assets/page.tsx
@@ -1,0 +1,365 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState, type CSSProperties } from 'react'
+import { useRouter } from 'next/navigation'
+import { Horizon, Keypair } from '@stellar/stellar-sdk'
+
+import { useInactivityLock } from '@/hooks/useInactivityLock'
+import { getNetwork } from '@/lib/network'
+import { requirePasskey } from '@/lib/passkeyAuth'
+import {
+  buildChangeTrustTx,
+  canRemoveTrustline,
+  hasTrustline,
+  parseTrustlines,
+  resolveAnchorAssets,
+  type AnchorAsset,
+  type HorizonBalanceLike,
+  type Trustline,
+} from '@/lib/trustlines'
+
+const Server = Horizon.Server
+const network = getNetwork()
+
+function getSignerSecret(): string | null {
+  return (
+    sessionStorage.getItem('veil_signer_secret') ||
+    localStorage.getItem('veil_signer_secret')
+  )
+}
+
+type Status = { kind: 'idle' | 'busy' | 'error' | 'success'; message?: string }
+
+export default function AssetsPage() {
+  const router = useRouter()
+  useInactivityLock()
+
+  const server = useMemo(() => new Server(network.horizonUrl), [])
+
+  const [signerAddress, setSignerAddress] = useState<string | null>(null)
+  const [balances, setBalances] = useState<HorizonBalanceLike[]>([])
+  const [loading, setLoading] = useState(true)
+  const [status, setStatus] = useState<Status>({ kind: 'idle' })
+
+  // Add-asset form
+  const [domain, setDomain] = useState('')
+  const [anchorAssets, setAnchorAssets] = useState<AnchorAsset[]>([])
+  const [searching, setSearching] = useState(false)
+  const [manualCode, setManualCode] = useState('')
+  const [manualIssuer, setManualIssuer] = useState('')
+
+  const trustlines: Trustline[] = useMemo(() => parseTrustlines(balances), [balances])
+
+  const loadAccount = useCallback(async () => {
+    setLoading(true)
+    try {
+      const secret = getSignerSecret()
+      if (!secret) {
+        setStatus({ kind: 'error', message: 'Wallet is locked. Unlock it to manage assets.' })
+        setLoading(false)
+        return
+      }
+      const pubKey = Keypair.fromSecret(secret).publicKey()
+      setSignerAddress(pubKey)
+      const account = await server.loadAccount(pubKey)
+      setBalances(account.balances as unknown as HorizonBalanceLike[])
+    } catch (err) {
+      setStatus({ kind: 'error', message: errorMessage(err) })
+    } finally {
+      setLoading(false)
+    }
+  }, [server])
+
+  useEffect(() => {
+    void loadAccount()
+  }, [loadAccount])
+
+  const submitChangeTrust = useCallback(
+    async (code: string, issuer: string, remove: boolean) => {
+      setStatus({ kind: 'busy', message: remove ? 'Removing trustline…' : 'Adding trustline…' })
+      try {
+        await requirePasskey()
+        const secret = getSignerSecret()
+        if (!secret) throw new Error('Signing key not found. Unlock the wallet again.')
+
+        const signer = Keypair.fromSecret(secret)
+        const account = await server.loadAccount(signer.publicKey())
+        const tx = buildChangeTrustTx({
+          account,
+          networkPassphrase: network.networkPassphrase,
+          code,
+          issuer,
+          remove,
+        })
+        tx.sign(signer)
+        await server.submitTransaction(tx)
+
+        setStatus({
+          kind: 'success',
+          message: remove ? `Removed trustline for ${code}.` : `Now trusting ${code}.`,
+        })
+        await loadAccount()
+      } catch (err) {
+        setStatus({ kind: 'error', message: errorMessage(err) })
+      }
+    },
+    [server, loadAccount],
+  )
+
+  const handleSearch = useCallback(async () => {
+    setSearching(true)
+    setAnchorAssets([])
+    setStatus({ kind: 'idle' })
+    try {
+      const assets = await resolveAnchorAssets(domain)
+      setAnchorAssets(assets)
+      if (assets.length === 0) {
+        setStatus({ kind: 'error', message: `No assets found in ${domain || 'that domain'}'s stellar.toml.` })
+      }
+    } catch (err) {
+      setStatus({ kind: 'error', message: `Could not read stellar.toml: ${errorMessage(err)}` })
+    } finally {
+      setSearching(false)
+    }
+  }, [domain])
+
+  const handleManualAdd = useCallback(() => {
+    const code = manualCode.trim()
+    const issuer = manualIssuer.trim()
+    if (!code || !issuer) {
+      setStatus({ kind: 'error', message: 'Enter both an asset code and issuer address.' })
+      return
+    }
+    void submitChangeTrust(code, issuer, false)
+  }, [manualCode, manualIssuer, submitChangeTrust])
+
+  const busy = status.kind === 'busy'
+
+  return (
+    <div className="wallet-shell">
+      <nav className="wallet-nav">
+        <button onClick={() => router.push('/dashboard')} style={backButtonStyle}>
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+            <path d="M10 3L5 8l5 5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+          Dashboard
+        </button>
+        <p style={navTitleStyle}>ASSETS</p>
+        <button onClick={() => void loadAccount()} title="Refresh" style={{ ...backButtonStyle, color: 'rgba(246,247,248,0.55)' }}>
+          Refresh
+        </button>
+      </nav>
+
+      <main className="wallet-main">
+        <div style={{ marginBottom: '1.5rem' }}>
+          <p style={eyebrowStyle}>TRUSTLINES</p>
+          <h1 style={headingStyle}>Manage the assets you hold</h1>
+          <p style={{ color: 'rgba(246,247,248,0.52)', fontSize: '0.875rem', lineHeight: 1.6, maxWidth: 460 }}>
+            Classic Stellar assets need a trustline before they can be received. Add one from an
+            anchor&apos;s stellar.toml or by issuer, and remove any you no longer need.
+          </p>
+        </div>
+
+        {status.message && (
+          <div
+            className="card"
+            role={status.kind === 'error' ? 'alert' : undefined}
+            style={{
+              marginBottom: '1rem',
+              borderColor: status.kind === 'error' ? 'rgba(229,72,77,0.4)' : 'rgba(0,167,181,0.24)',
+              background: status.kind === 'error' ? 'rgba(229,72,77,0.07)' : 'rgba(0,167,181,0.06)',
+            }}
+          >
+            <p style={{ fontSize: '0.875rem', color: 'var(--off-white)' }}>{status.message}</p>
+          </div>
+        )}
+
+        {/* Existing trustlines */}
+        <section style={{ marginBottom: '2rem' }}>
+          <h2 style={sectionHeadingStyle}>Your trustlines</h2>
+          {loading ? (
+            <p style={mutedTextStyle}>Loading…</p>
+          ) : trustlines.length === 0 ? (
+            <p style={mutedTextStyle}>No trustlines yet. Add one below.</p>
+          ) : (
+            trustlines.map((line) => (
+              <div key={`${line.code}-${line.issuer}`} className="card" style={trustlineRowStyle}>
+                <div style={{ minWidth: 0 }}>
+                  <p style={{ fontWeight: 600, color: 'var(--off-white)' }}>{line.code}</p>
+                  <p style={{ ...mutedTextStyle, fontFamily: 'monospace', fontSize: '0.7rem', wordBreak: 'break-all' }}>
+                    {line.issuer}
+                  </p>
+                  <p style={mutedTextStyle}>Balance: {line.balance}</p>
+                </div>
+                <button
+                  onClick={() => void submitChangeTrust(line.code, line.issuer, true)}
+                  disabled={busy || !canRemoveTrustline(line)}
+                  title={canRemoveTrustline(line) ? 'Remove trustline' : 'Balance must be zero to remove'}
+                  style={removeButtonStyle(busy || !canRemoveTrustline(line))}
+                >
+                  Remove
+                </button>
+              </div>
+            ))
+          )}
+        </section>
+
+        {/* Add by anchor domain */}
+        <section style={{ marginBottom: '2rem' }}>
+          <h2 style={sectionHeadingStyle}>Add from an anchor</h2>
+          <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '0.75rem' }}>
+            <input
+              value={domain}
+              onChange={(e) => setDomain(e.target.value)}
+              placeholder="anchor domain, e.g. centre.io"
+              style={inputStyle}
+              aria-label="Anchor domain"
+            />
+            <button onClick={() => void handleSearch()} disabled={searching || !domain.trim()} style={primaryButtonStyle(searching || !domain.trim())}>
+              {searching ? 'Searching…' : 'Search'}
+            </button>
+          </div>
+          {anchorAssets.map((asset) => {
+            const already = hasTrustline(balances, asset.code, asset.issuer)
+            return (
+              <div key={`${asset.code}-${asset.issuer}`} className="card" style={trustlineRowStyle}>
+                <div style={{ minWidth: 0 }}>
+                  <p style={{ fontWeight: 600, color: 'var(--off-white)' }}>{asset.code}</p>
+                  <p style={{ ...mutedTextStyle, fontFamily: 'monospace', fontSize: '0.7rem', wordBreak: 'break-all' }}>
+                    {asset.issuer}
+                  </p>
+                </div>
+                <button
+                  onClick={() => void submitChangeTrust(asset.code, asset.issuer, false)}
+                  disabled={busy || already}
+                  style={primaryButtonStyle(busy || already)}
+                >
+                  {already ? 'Added' : 'Add'}
+                </button>
+              </div>
+            )
+          })}
+        </section>
+
+        {/* Add manually */}
+        <section>
+          <h2 style={sectionHeadingStyle}>Add by issuer</h2>
+          <input
+            value={manualCode}
+            onChange={(e) => setManualCode(e.target.value)}
+            placeholder="Asset code, e.g. USDC"
+            style={{ ...inputStyle, marginBottom: '0.5rem' }}
+            aria-label="Asset code"
+          />
+          <input
+            value={manualIssuer}
+            onChange={(e) => setManualIssuer(e.target.value)}
+            placeholder="Issuer address (G…)"
+            style={{ ...inputStyle, marginBottom: '0.75rem' }}
+            aria-label="Issuer address"
+          />
+          <button onClick={handleManualAdd} disabled={busy} style={primaryButtonStyle(busy)}>
+            Add trustline
+          </button>
+        </section>
+      </main>
+    </div>
+  )
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}
+
+const backButtonStyle: CSSProperties = {
+  background: 'none',
+  border: 'none',
+  cursor: 'pointer',
+  color: 'var(--off-white)',
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.375rem',
+  fontSize: '0.875rem',
+}
+
+const navTitleStyle: CSSProperties = {
+  fontSize: '0.75rem',
+  fontFamily: 'Anton, Impact, sans-serif',
+  letterSpacing: '0.08em',
+  color: 'var(--warm-grey)',
+}
+
+const eyebrowStyle: CSSProperties = {
+  fontSize: '0.75rem',
+  fontFamily: 'Anton, Impact, sans-serif',
+  color: 'var(--warm-grey)',
+  letterSpacing: '0.08em',
+  marginBottom: '0.5rem',
+}
+
+const headingStyle: CSSProperties = {
+  fontFamily: 'Lora, Georgia, serif',
+  fontWeight: 600,
+  fontStyle: 'italic',
+  fontSize: '1.9rem',
+  lineHeight: 1.1,
+  marginBottom: '0.5rem',
+}
+
+const sectionHeadingStyle: CSSProperties = {
+  fontSize: '0.95rem',
+  fontWeight: 600,
+  color: 'var(--off-white)',
+  marginBottom: '0.75rem',
+}
+
+const mutedTextStyle: CSSProperties = {
+  color: 'var(--warm-grey)',
+  fontSize: '0.8125rem',
+}
+
+const trustlineRowStyle: CSSProperties = {
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  gap: '1rem',
+  marginBottom: '0.5rem',
+}
+
+const inputStyle: CSSProperties = {
+  flex: 1,
+  width: '100%',
+  background: 'var(--near-black)',
+  border: '1px solid var(--border-dim)',
+  borderRadius: '0.5rem',
+  padding: '0.625rem 0.75rem',
+  color: 'var(--off-white)',
+  fontSize: '0.875rem',
+}
+
+function primaryButtonStyle(disabled: boolean): CSSProperties {
+  return {
+    background: disabled ? 'rgba(246,247,248,0.1)' : 'var(--gold)',
+    color: disabled ? 'var(--warm-grey)' : 'var(--near-black)',
+    border: 'none',
+    borderRadius: '0.5rem',
+    padding: '0.625rem 1rem',
+    fontWeight: 600,
+    fontSize: '0.875rem',
+    cursor: disabled ? 'not-allowed' : 'pointer',
+    whiteSpace: 'nowrap',
+  }
+}
+
+function removeButtonStyle(disabled: boolean): CSSProperties {
+  return {
+    background: 'none',
+    border: '1px solid var(--border-dim)',
+    borderRadius: '0.5rem',
+    padding: '0.5rem 0.875rem',
+    color: disabled ? 'var(--warm-grey)' : '#e5484d',
+    fontSize: '0.8125rem',
+    cursor: disabled ? 'not-allowed' : 'pointer',
+    whiteSpace: 'nowrap',
+  }
+}

--- a/frontend/wallet/lib/__tests__/trustlines.test.ts
+++ b/frontend/wallet/lib/__tests__/trustlines.test.ts
@@ -1,0 +1,107 @@
+// @stellar/stellar-sdk needs TextEncoder at module load; jsdom omits it.
+import { TextEncoder, TextDecoder } from 'util'
+Object.assign(globalThis, { TextEncoder, TextDecoder })
+
+import { Account, Keypair, Networks, type Operation } from '@stellar/stellar-sdk'
+import {
+  buildChangeTrustTx,
+  canRemoveTrustline,
+  hasTrustline,
+  normalizeDomain,
+  parseTrustlines,
+  resolveAnchorAssets,
+  type HorizonBalanceLike,
+} from '../trustlines'
+
+const ISSUER = Keypair.random().publicKey()
+
+const BALANCES: HorizonBalanceLike[] = [
+  { asset_type: 'native', balance: '100' },
+  { asset_type: 'credit_alphanum4', asset_code: 'USDC', asset_issuer: ISSUER, balance: '5', limit: '1000' },
+  { asset_type: 'credit_alphanum12', asset_code: 'LONGASSET', asset_issuer: ISSUER, balance: '0', limit: '50' },
+  { asset_type: 'liquidity_pool_shares', balance: '3' },
+]
+
+describe('parseTrustlines', () => {
+  it('keeps only classic credit assets with a code and issuer', () => {
+    const lines = parseTrustlines(BALANCES)
+    expect(lines.map((l) => l.code)).toEqual(['USDC', 'LONGASSET'])
+    expect(lines[0]).toMatchObject({ code: 'USDC', issuer: ISSUER, balance: '5', limit: '1000' })
+  })
+})
+
+describe('hasTrustline', () => {
+  it('detects an existing trustline', () => {
+    expect(hasTrustline(BALANCES, 'USDC', ISSUER)).toBe(true)
+    expect(hasTrustline(BALANCES, 'EURC', ISSUER)).toBe(false)
+  })
+})
+
+describe('canRemoveTrustline', () => {
+  it('only allows removal at a zero balance', () => {
+    expect(canRemoveTrustline({ code: 'A', issuer: ISSUER, balance: '0', limit: '1', assetType: 'credit_alphanum4' })).toBe(true)
+    expect(canRemoveTrustline({ code: 'A', issuer: ISSUER, balance: '5', limit: '1', assetType: 'credit_alphanum4' })).toBe(false)
+  })
+})
+
+describe('buildChangeTrustTx', () => {
+  const account = () => new Account(Keypair.random().publicKey(), '0')
+
+  it('adds a trustline at a non-zero limit', () => {
+    const tx = buildChangeTrustTx({
+      account: account(),
+      networkPassphrase: Networks.TESTNET,
+      code: 'USDC',
+      issuer: ISSUER,
+    })
+    const op = tx.operations[0] as Operation.ChangeTrust
+    expect(op.type).toBe('changeTrust')
+    expect((op.line as { code: string }).code).toBe('USDC')
+    expect(Number(op.limit)).toBeGreaterThan(0)
+  })
+
+  it('removes a trustline by setting the limit to zero', () => {
+    const tx = buildChangeTrustTx({
+      account: account(),
+      networkPassphrase: Networks.TESTNET,
+      code: 'USDC',
+      issuer: ISSUER,
+      remove: true,
+    })
+    const op = tx.operations[0] as Operation.ChangeTrust
+    expect(op.type).toBe('changeTrust')
+    expect(Number(op.limit)).toBe(0)
+  })
+})
+
+describe('normalizeDomain', () => {
+  it('strips scheme, path and whitespace', () => {
+    expect(normalizeDomain('  https://centre.io/path/x ')).toBe('centre.io')
+    expect(normalizeDomain('example.com')).toBe('example.com')
+    expect(normalizeDomain('')).toBe('')
+  })
+})
+
+describe('resolveAnchorAssets', () => {
+  it('maps stellar.toml CURRENCIES and drops incomplete entries', async () => {
+    const resolver = async () => ({
+      CURRENCIES: [
+        { code: 'USDC', issuer: ISSUER },
+        { code: 'NOISSUER' },
+        { issuer: ISSUER },
+      ],
+    })
+    const assets = await resolveAnchorAssets('centre.io', resolver)
+    expect(assets).toEqual([{ code: 'USDC', issuer: ISSUER }])
+  })
+
+  it('returns an empty list for a blank domain without calling the resolver', async () => {
+    let called = false
+    const resolver = async () => {
+      called = true
+      return {}
+    }
+    expect(await resolveAnchorAssets('  ', resolver)).toEqual([])
+    expect(called).toBe(false)
+  })
+})

--- a/frontend/wallet/lib/trustlines.ts
+++ b/frontend/wallet/lib/trustlines.ts
@@ -1,0 +1,135 @@
+import {
+  Asset,
+  BASE_FEE,
+  Operation,
+  StellarToml,
+  TransactionBuilder,
+  type Account,
+  type Transaction,
+} from '@stellar/stellar-sdk'
+
+/**
+ * Trustline management helpers (issue #343).
+ *
+ * Classic Stellar assets require a trustline before they can be held. These
+ * helpers read existing trustlines from a Horizon account, build the
+ * passkey-signed `changeTrust` transactions that add or remove them, and look
+ * up assets from an anchor's stellar.toml.
+ */
+
+/** Subset of a Horizon balance entry we depend on. */
+export interface HorizonBalanceLike {
+  asset_type: string
+  asset_code?: string
+  asset_issuer?: string
+  balance: string
+  limit?: string
+}
+
+export interface Trustline {
+  code: string
+  issuer: string
+  balance: string
+  limit: string
+  assetType: string
+}
+
+export interface AnchorAsset {
+  code: string
+  issuer: string
+}
+
+/** Setting a trustline limit to zero removes it (only allowed at zero balance). */
+export const REMOVE_TRUSTLINE_LIMIT = '0'
+
+/** Extracts the classic (non-native, non-pool-share) trustlines from balances. */
+export function parseTrustlines(balances: HorizonBalanceLike[]): Trustline[] {
+  return balances
+    .filter(
+      (b) =>
+        b.asset_type === 'credit_alphanum4' || b.asset_type === 'credit_alphanum12',
+    )
+    .filter((b) => b.asset_code && b.asset_issuer)
+    .map((b) => ({
+      code: b.asset_code as string,
+      issuer: b.asset_issuer as string,
+      balance: b.balance,
+      limit: b.limit ?? REMOVE_TRUSTLINE_LIMIT,
+      assetType: b.asset_type,
+    }))
+}
+
+/** True when the account already trusts `code:issuer`. */
+export function hasTrustline(
+  balances: HorizonBalanceLike[],
+  code: string,
+  issuer: string,
+): boolean {
+  return balances.some((b) => b.asset_code === code && b.asset_issuer === issuer)
+}
+
+/**
+ * A trustline can only be removed when its balance is exactly zero — Stellar
+ * rejects a `changeTrust` to zero while the holder still owns the asset.
+ */
+export function canRemoveTrustline(trustline: Trustline): boolean {
+  return Number(trustline.balance) === 0
+}
+
+/**
+ * Builds a `changeTrust` transaction for `code:issuer`. Pass `remove: true` to
+ * delete the trustline; otherwise it is added at the maximum limit (or
+ * `limit`, when provided). The returned transaction still needs to be signed.
+ */
+export function buildChangeTrustTx(params: {
+  account: Account
+  networkPassphrase: string
+  code: string
+  issuer: string
+  remove?: boolean
+  limit?: string
+}): Transaction {
+  const asset = new Asset(params.code, params.issuer)
+  const limit = params.remove ? REMOVE_TRUSTLINE_LIMIT : params.limit
+
+  return new TransactionBuilder(params.account, {
+    fee: BASE_FEE,
+    networkPassphrase: params.networkPassphrase,
+  })
+    .addOperation(
+      Operation.changeTrust(limit !== undefined ? { asset, limit } : { asset }),
+    )
+    .setTimeout(30)
+    .build()
+}
+
+type StellarTomlLike = {
+  CURRENCIES?: Array<{ code?: string; issuer?: string }>
+}
+
+/** Strips scheme and path so a stellar.toml resolver receives a bare domain. */
+export function normalizeDomain(input: string): string {
+  return input
+    .trim()
+    .replace(/^https?:\/\//i, '')
+    .replace(/\/.*$/, '')
+    .trim()
+}
+
+/**
+ * Resolves an anchor's stellar.toml and returns its declared assets. The
+ * resolver is injectable so the lookup can be unit-tested without the network.
+ */
+export async function resolveAnchorAssets(
+  domain: string,
+  resolver: (domain: string) => Promise<StellarTomlLike> = (d) =>
+    StellarToml.Resolver.resolve(d),
+): Promise<AnchorAsset[]> {
+  const normalized = normalizeDomain(domain)
+  if (!normalized) return []
+
+  const toml = await resolver(normalized)
+  return (toml.CURRENCIES ?? [])
+    .filter((c): c is AnchorAsset => Boolean(c.code && c.issuer))
+    .map((c) => ({ code: c.code, issuer: c.issuer }))
+}


### PR DESCRIPTION
## Summary

Implements **#343** — a UI to view, add, and remove classic Stellar asset **trustlines**. Several wallet flows (swap, pools, withdraw) already create trustlines on demand, but there was no dedicated place to manage them.

## What's included (the issue's key files)

- **`frontend/wallet/lib/trustlines.ts`**
  - `parseTrustlines(balances)` — extracts classic (`credit_alphanum4/12`) trustlines from a Horizon account's balances.
  - `buildChangeTrustTx({ account, networkPassphrase, code, issuer, remove? })` — builds the `changeTrust` transaction; `remove: true` sets the limit to `0` to delete it. Returns an unsigned tx.
  - `canRemoveTrustline(line)` — enforces Stellar's rule that a trustline can only be removed at a zero balance.
  - `resolveAnchorAssets(domain, resolver?)` — looks up assets from an anchor's `stellar.toml` via `StellarToml.Resolver` (the resolver is injectable for tests); `normalizeDomain()` strips scheme/path.
- **`frontend/wallet/app/assets/page.tsx`**
  - Lists current trustlines with a **passkey-signed remove** action (disabled until balance is zero).
  - "Add from an anchor" — enter a domain, search its `stellar.toml`, add any listed asset.
  - "Add by issuer" — manual code + issuer entry.
  - Each add/remove runs `requirePasskey()` → `changeTrust` → sign → `submitTransaction`, matching the existing swap/pools flow.
- **`frontend/wallet/lib/__tests__/trustlines.test.ts`** — 8 tests.

## Acceptance criteria

- [x] Add/remove trustline via passkey-signed tx
- [x] Lists existing trustlines

## Testing

Run in `frontend/wallet`:

- `npm run typecheck` — clean
- `npm run build` — clean (new `/assets` route compiles)
- `npx jest lib/__tests__/trustlines.test.ts` — 8/8 pass (parsing, zero-balance guard, add/remove tx building, domain normalization, stellar.toml resolution)

> Note: this issue requires joining the contributor Telegram before the work counts toward the Stellar Wave.

Closes #343
