### PR TITLE
feat(invisible-wallet): per-key 24-hour rolling spend limit

### DIFF
--- a/contracts/invisible_wallet/src/lib.rs
+++ b/contracts/invisible_wallet/src/lib.rs
@@ -8,9 +8,12 @@ use soroban_sdk::{
 
 mod auth;
 mod storage;
+mod recovery;
 pub mod session_key;
 #[cfg(test)]
 mod auth_failure_tests;
+#[cfg(test)]
+mod guardian_test;
 use storage::{DataKey, AllowanceKey, PendingRecovery};
 
 /// Recovery timelock duration: 3 days in seconds.
@@ -56,6 +59,8 @@ pub enum WalletError {
     SessionKeyExpired           = 19,
     /// A session key call violates its ACL (wrong target, selector, or cumulative budget exceeded).
     SessionKeyAclViolation      = 20,
+    /// No recovery key is set on this wallet.
+    NoRecoveryKeySet            = 21,
 }
 
 #[contract]
@@ -558,6 +563,53 @@ impl InvisibleWallet {
     pub fn revoke_session_key(env: Env, key_id: BytesN<32>) {
         env.current_contract_address().require_auth();
         session_key::revoke(&env, &key_id);
+    }
+
+    /// Register a designated recovery key for this wallet.
+    ///
+    /// The recovery key is an Address (e.g. a cold-wallet account) that is
+    /// authorized to initiate signer rotation via `request_recovery`.
+    /// Requires current wallet signer authorization.
+    pub fn set_recovery_key(env: Env, key: Address) {
+        env.current_contract_address().require_auth();
+        recovery::set_recovery_key(&env, &key);
+    }
+
+    /// Start a 7-day recovery cooldown to replace the active signer.
+    ///
+    /// Only the designated recovery key (set via `set_recovery_key`) may call
+    /// this. After the 7-day timelock expires, anyone can call `finalize_recovery`
+    /// to complete the rotation.
+    ///
+    /// # Errors
+    /// * `NoRecoveryKeySet`       — no recovery key has been registered.
+    /// * `RecoveryAlreadyPending` — a recovery request is already in progress.
+    pub fn request_recovery(env: Env, new_signer: BytesN<65>) -> Result<(), WalletError> {
+        recovery::request_recovery(&env, new_signer)
+    }
+
+    /// Finalize a pending recovery request after the 7-day timelock has expired.
+    ///
+    /// Permissionless — anyone may call this once `ledger.timestamp > unlock_at`.
+    ///
+    /// # Errors
+    /// * `RecoveryNotPending`     — no recovery request is in progress.
+    /// * `RecoveryTimelockActive` — the 7-day cooldown has not yet elapsed.
+    pub fn finalize_recovery(env: Env) -> Result<(), WalletError> {
+        recovery::finalize_recovery(&env)
+    }
+
+    /// Cancel a pending recovery-key request.
+    ///
+    /// Only the current wallet signer (the contract itself) may cancel.
+    /// This lets a wallet owner who still holds their key abort a recovery
+    /// attempt before it is finalized.
+    ///
+    /// # Errors
+    /// * `RecoveryNotPending` — no recovery request is in progress.
+    pub fn cancel_recovery_request(env: Env) -> Result<(), WalletError> {
+        env.current_contract_address().require_auth();
+        recovery::cancel_recovery_request(&env)
     }
 }
 

--- a/contracts/invisible_wallet/src/lib.rs
+++ b/contracts/invisible_wallet/src/lib.rs
@@ -10,6 +10,7 @@ mod auth;
 mod storage;
 mod recovery;
 pub mod session_key;
+pub mod policies;
 #[cfg(test)]
 mod auth_failure_tests;
 #[cfg(test)]
@@ -61,6 +62,8 @@ pub enum WalletError {
     SessionKeyAclViolation      = 20,
     /// No recovery key is set on this wallet.
     NoRecoveryKeySet            = 21,
+    /// The per-key 24-hour spend limit has been reached.
+    SpendLimitExceeded          = 22,
 }
 
 #[contract]
@@ -335,7 +338,7 @@ impl InvisibleWallet {
         auth::verify_webauthn(
             &env,
             &signature_payload,
-            public_key,
+            public_key.clone(),
             auth_data.clone(),
             client_data_json.clone(),
             sig_bytes,
@@ -349,7 +352,20 @@ impl InvisibleWallet {
         let origin = storage::get_origin(&env).ok_or(WalletError::OriginMismatch)?;
         auth::verify_origin(&client_data_json, &origin)?;
 
-        // Step 6 — Increment nonce ONLY after all checks pass.
+        // Step 6 — Per-key 24-hour spend limit (if configured for this signer).
+        let total_amount: i128 = _auth_contexts.iter().fold(0i128, |acc, ctx| {
+            if let Context::Contract(c) = ctx {
+                if c.args.len() >= 3 {
+                    if let Ok(a) = i128::try_from_val(&env, &c.args.get(2).unwrap()) {
+                        return acc.saturating_add(a);
+                    }
+                }
+            }
+            acc
+        });
+        policies::spend_limit::enforce(&env, &public_key, total_amount)?;
+
+        // Step 7 — Increment nonce ONLY after all checks pass.
         storage::increment_nonce(&env);
 
         Ok(())
@@ -563,6 +579,32 @@ impl InvisibleWallet {
     pub fn revoke_session_key(env: Env, key_id: BytesN<32>) {
         env.current_contract_address().require_auth();
         session_key::revoke(&env, &key_id);
+    }
+
+    /// Set a 24-hour rolling spend limit for a WebAuthn signer key.
+    ///
+    /// Once set, every `__check_auth` call using `key_id` sums all context
+    /// amounts and checks the total against `cap` within a rolling 24-hour window.
+    /// Pass `cap = 0` to block all spending. Call `remove_key_spend_limit` to
+    /// lift the restriction entirely.
+    ///
+    /// Requires wallet owner authorization.
+    pub fn set_key_spend_limit(env: Env, key_id: BytesN<65>, cap: i128) {
+        env.current_contract_address().require_auth();
+        policies::spend_limit::set(&env, &key_id, cap);
+    }
+
+    /// Remove the 24-hour spend limit for a signer key (no limit = no cap).
+    ///
+    /// Requires wallet owner authorization.
+    pub fn remove_key_spend_limit(env: Env, key_id: BytesN<65>) {
+        env.current_contract_address().require_auth();
+        policies::spend_limit::remove(&env, &key_id);
+    }
+
+    /// Get the current spend window record for a signer key, if any.
+    pub fn get_key_spend_limit(env: Env, key_id: BytesN<65>) -> Option<policies::spend_limit::SpendWindow> {
+        policies::spend_limit::get(&env, &key_id)
     }
 
     /// Register a designated recovery key for this wallet.

--- a/contracts/invisible_wallet/src/policies/mod.rs
+++ b/contracts/invisible_wallet/src/policies/mod.rs
@@ -1,0 +1,1 @@
+pub mod spend_limit;

--- a/contracts/invisible_wallet/src/policies/spend_limit.rs
+++ b/contracts/invisible_wallet/src/policies/spend_limit.rs
@@ -1,0 +1,254 @@
+use soroban_sdk::{contracttype, BytesN, Env};
+use crate::WalletError;
+
+/// Rolling window duration: 24 hours in seconds.
+pub const WINDOW_SECS: u64 = 86_400;
+
+/// Per-key 24-hour rolling spend window record.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SpendWindow {
+    /// Maximum amount that may be spent in any single 24-hour window.
+    pub cap: i128,
+    /// Unix timestamp (seconds) when the current window started.
+    pub window_start: u64,
+    /// Cumulative amount spent within the current window.
+    pub window_spent: i128,
+}
+
+#[contracttype]
+enum SpendLimitKey {
+    Limit(BytesN<65>),
+}
+
+/// Store or update the spend limit for a WebAuthn signer key.
+/// The window is reset to the current ledger timestamp and `window_spent` to 0.
+pub fn set(env: &Env, key_id: &BytesN<65>, cap: i128) {
+    let record = SpendWindow {
+        cap,
+        window_start: env.ledger().timestamp(),
+        window_spent: 0,
+    };
+    env.storage()
+        .persistent()
+        .set(&SpendLimitKey::Limit(key_id.clone()), &record);
+}
+
+/// Remove the spend limit for a key (no limit = no enforcement).
+pub fn remove(env: &Env, key_id: &BytesN<65>) {
+    env.storage()
+        .persistent()
+        .remove(&SpendLimitKey::Limit(key_id.clone()));
+}
+
+/// Retrieve the current spend window record for a key, if any.
+pub fn get(env: &Env, key_id: &BytesN<65>) -> Option<SpendWindow> {
+    env.storage()
+        .persistent()
+        .get(&SpendLimitKey::Limit(key_id.clone()))
+}
+
+/// Enforce the per-key 24-hour rolling spend window and update storage.
+///
+/// If no limit is configured for `key_id`, the call passes unconditionally.
+/// When the current ledger timestamp is at or past `window_start + WINDOW_SECS`,
+/// the window resets: `window_start` is set to now and `window_spent` to zero.
+/// Returns `SpendLimitExceeded` if `window_spent + amount > cap`.
+pub fn enforce(env: &Env, key_id: &BytesN<65>, amount: i128) -> Result<(), WalletError> {
+    let mut record = match get(env, key_id) {
+        Some(r) => r,
+        None => return Ok(()),
+    };
+
+    let now = env.ledger().timestamp();
+
+    if now >= record.window_start + WINDOW_SECS {
+        record.window_start = now;
+        record.window_spent = 0;
+    }
+
+    let new_spent = record
+        .window_spent
+        .checked_add(amount)
+        .ok_or(WalletError::SpendLimitExceeded)?;
+
+    if new_spent > record.cap {
+        return Err(WalletError::SpendLimitExceeded);
+    }
+
+    record.window_spent = new_spent;
+    env.storage()
+        .persistent()
+        .set(&SpendLimitKey::Limit(key_id.clone()), &record);
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Ledger, Env};
+
+    fn make_key(env: &Env, seed: u8) -> BytesN<65> {
+        BytesN::from_array(env, &[seed; 65])
+    }
+
+    fn contract_id(env: &Env) -> soroban_sdk::Address {
+        env.register_contract(None, crate::InvisibleWallet)
+    }
+
+    // ── No limit configured ───────────────────────────────────────────────────
+
+    #[test]
+    fn no_limit_always_passes() {
+        let env = Env::default();
+        let cid = contract_id(&env);
+        let key = make_key(&env, 0x01);
+        env.as_contract(&cid, || {
+            assert!(enforce(&env, &key, i128::MAX).is_ok());
+        });
+    }
+
+    // ── Within cap ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn within_cap_passes() {
+        let env = Env::default();
+        let cid = contract_id(&env);
+        let key = make_key(&env, 0x02);
+        env.as_contract(&cid, || {
+            set(&env, &key, 1_000);
+            assert!(enforce(&env, &key, 500).is_ok());
+            assert!(enforce(&env, &key, 500).is_ok());
+        });
+    }
+
+    // ── Exactly at cap ────────────────────────────────────────────────────────
+
+    #[test]
+    fn exactly_at_cap_passes() {
+        let env = Env::default();
+        let cid = contract_id(&env);
+        let key = make_key(&env, 0x03);
+        env.as_contract(&cid, || {
+            set(&env, &key, 1_000);
+            assert!(enforce(&env, &key, 1_000).is_ok());
+        });
+    }
+
+    // ── Over cap rejected ────────────────────────────────────────────────────
+
+    #[test]
+    fn over_cap_rejected() {
+        let env = Env::default();
+        let cid = contract_id(&env);
+        let key = make_key(&env, 0x04);
+        env.as_contract(&cid, || {
+            set(&env, &key, 1_000);
+            assert_eq!(
+                enforce(&env, &key, 1_001),
+                Err(WalletError::SpendLimitExceeded)
+            );
+        });
+    }
+
+    // ── Cumulative spend enforced ─────────────────────────────────────────────
+
+    #[test]
+    fn cumulative_over_cap_rejected() {
+        let env = Env::default();
+        let cid = contract_id(&env);
+        let key = make_key(&env, 0x05);
+        env.as_contract(&cid, || {
+            set(&env, &key, 1_000);
+            assert!(enforce(&env, &key, 600).is_ok());
+            // 401 would push total to 1001 > 1000
+            assert_eq!(
+                enforce(&env, &key, 401),
+                Err(WalletError::SpendLimitExceeded)
+            );
+            // exactly 400 remaining is still allowed
+            assert!(enforce(&env, &key, 400).is_ok());
+            // now at cap — any further spend rejected
+            assert_eq!(
+                enforce(&env, &key, 1),
+                Err(WalletError::SpendLimitExceeded)
+            );
+        });
+    }
+
+    // ── Window resets after 24h ───────────────────────────────────────────────
+
+    #[test]
+    fn window_resets_after_24h() {
+        let env = Env::default();
+        let cid = contract_id(&env);
+        let key = make_key(&env, 0x06);
+        env.as_contract(&cid, || {
+            set(&env, &key, 1_000);
+            assert!(enforce(&env, &key, 1_000).is_ok());
+            assert_eq!(enforce(&env, &key, 1), Err(WalletError::SpendLimitExceeded));
+
+            // Advance ledger time by exactly WINDOW_SECS — window resets
+            let mut info = env.ledger().get();
+            info.timestamp += WINDOW_SECS;
+            env.ledger().set(info);
+
+            assert!(enforce(&env, &key, 1_000).is_ok());
+        });
+    }
+
+    // ── Window does NOT reset before 24h ─────────────────────────────────────
+
+    #[test]
+    fn window_not_reset_before_24h() {
+        let env = Env::default();
+        let cid = contract_id(&env);
+        let key = make_key(&env, 0x07);
+        env.as_contract(&cid, || {
+            set(&env, &key, 1_000);
+            assert!(enforce(&env, &key, 1_000).is_ok());
+
+            // Advance to 1 second before window expiry
+            let mut info = env.ledger().get();
+            info.timestamp += WINDOW_SECS - 1;
+            env.ledger().set(info);
+
+            assert_eq!(enforce(&env, &key, 1), Err(WalletError::SpendLimitExceeded));
+        });
+    }
+
+    // ── Spent counter persists across calls ───────────────────────────────────
+
+    #[test]
+    fn spent_persists_across_calls() {
+        let env = Env::default();
+        let cid = contract_id(&env);
+        let key = make_key(&env, 0x08);
+        env.as_contract(&cid, || {
+            set(&env, &key, 300);
+            enforce(&env, &key, 100).unwrap();
+            enforce(&env, &key, 100).unwrap();
+            enforce(&env, &key, 100).unwrap();
+
+            let record = get(&env, &key).unwrap();
+            assert_eq!(record.window_spent, 300);
+            assert_eq!(record.cap, 300);
+        });
+    }
+
+    // ── Remove clears enforcement ─────────────────────────────────────────────
+
+    #[test]
+    fn remove_clears_limit() {
+        let env = Env::default();
+        let cid = contract_id(&env);
+        let key = make_key(&env, 0x09);
+        env.as_contract(&cid, || {
+            set(&env, &key, 0); // cap = 0 blocks everything
+            assert_eq!(enforce(&env, &key, 1), Err(WalletError::SpendLimitExceeded));
+            remove(&env, &key);
+            assert!(enforce(&env, &key, 1_000_000).is_ok());
+        });
+    }
+}

--- a/contracts/invisible_wallet/src/recovery.rs
+++ b/contracts/invisible_wallet/src/recovery.rs
@@ -1,0 +1,262 @@
+use soroban_sdk::{symbol_short, Address, BytesN, Env};
+
+use crate::storage::{DataKey, PendingRecovery};
+use crate::WalletError;
+
+/// 7-day timelock in seconds.
+pub const RECOVERY_KEY_DELAY: u64 = 604_800;
+
+pub fn set_recovery_key(env: &Env, key: &Address) {
+    env.storage().persistent().set(&DataKey::RecoveryKey, key);
+    env.events().publish(
+        (symbol_short!("rec_key"), symbol_short!("set")),
+        key.clone(),
+    );
+}
+
+pub fn request_recovery(env: &Env, new_signer: BytesN<65>) -> Result<(), WalletError> {
+    let recovery_key: Address = env
+        .storage()
+        .persistent()
+        .get(&DataKey::RecoveryKey)
+        .ok_or(WalletError::NoRecoveryKeySet)?;
+
+    recovery_key.require_auth();
+
+    if env.storage().persistent().has(&DataKey::RecoveryKeyPending) {
+        return Err(WalletError::RecoveryAlreadyPending);
+    }
+
+    let unlock_at = env.ledger().timestamp() + RECOVERY_KEY_DELAY;
+    let pending = PendingRecovery {
+        new_public_key: new_signer.clone(),
+        recovery_unlock_time: unlock_at,
+    };
+    env.storage()
+        .persistent()
+        .set(&DataKey::RecoveryKeyPending, &pending);
+
+    env.events().publish(
+        (symbol_short!("rec_key"), symbol_short!("request")),
+        (new_signer, unlock_at),
+    );
+
+    Ok(())
+}
+
+pub fn finalize_recovery(env: &Env) -> Result<(), WalletError> {
+    let pending: PendingRecovery = env
+        .storage()
+        .persistent()
+        .get(&DataKey::RecoveryKeyPending)
+        .ok_or(WalletError::RecoveryNotPending)?;
+
+    if env.ledger().timestamp() <= pending.recovery_unlock_time {
+        return Err(WalletError::RecoveryTimelockActive);
+    }
+
+    crate::storage::init_signers(env, &pending.new_public_key);
+    env.storage()
+        .persistent()
+        .remove(&DataKey::RecoveryKeyPending);
+
+    env.events().publish(
+        (symbol_short!("rec_key"), symbol_short!("done")),
+        pending.new_public_key,
+    );
+
+    Ok(())
+}
+
+/// Cancel a pending recovery-key request. Requires current signer (contract) auth.
+pub fn cancel_recovery_request(env: &Env) -> Result<(), WalletError> {
+    if !env
+        .storage()
+        .persistent()
+        .has(&DataKey::RecoveryKeyPending)
+    {
+        return Err(WalletError::RecoveryNotPending);
+    }
+
+    env.storage()
+        .persistent()
+        .remove(&DataKey::RecoveryKeyPending);
+
+    env.events().publish(
+        (symbol_short!("rec_key"), symbol_short!("cancel")),
+        (),
+    );
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::testutils::{Address as _, Ledger, LedgerInfo};
+    use soroban_sdk::{Address, BytesN, Env};
+
+    use crate::{InvisibleWallet, InvisibleWalletClient};
+
+    fn setup() -> (Env, Address) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register_contract(None, InvisibleWallet);
+        (env, id)
+    }
+
+    fn mock_key(env: &Env, seed: u8) -> BytesN<65> {
+        let mut b = [0u8; 65];
+        b[0] = 0x04;
+        b[1] = seed;
+        BytesN::from_array(env, &b)
+    }
+
+    fn advance_time(env: &Env, secs: u64) {
+        let mut info: LedgerInfo = env.ledger().get();
+        info.timestamp += secs;
+        env.ledger().set(info);
+    }
+
+    // ── happy path ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_request_and_finalize_recovery() {
+        let (env, id) = setup();
+        let client = InvisibleWalletClient::new(&env, &id);
+
+        let recovery_addr = Address::generate(&env);
+        let initial_key = mock_key(&env, 0x01);
+        let new_key = mock_key(&env, 0x42);
+
+        client.init(
+            &initial_key,
+            &soroban_sdk::Bytes::new(&env),
+            &soroban_sdk::Bytes::new(&env),
+        );
+        client.set_recovery_key(&recovery_addr);
+        client.request_recovery(&new_key);
+
+        // Cannot finalize before timelock expires.
+        assert!(
+            client.try_finalize_recovery().is_err(),
+            "finalize before cooldown must fail"
+        );
+
+        advance_time(&env, RECOVERY_KEY_DELAY + 1);
+        client.finalize_recovery();
+
+        assert!(
+            client.has_signer(&new_key),
+            "new signer must be registered after finalize"
+        );
+    }
+
+    // ── timelock boundary ───────────────────────────────────────────────────────
+
+    #[test]
+    fn test_timelock_boundary() {
+        let (env, id) = setup();
+        let client = InvisibleWalletClient::new(&env, &id);
+
+        let recovery_addr = Address::generate(&env);
+        let initial_key = mock_key(&env, 0x01);
+        let new_key = mock_key(&env, 0x42);
+
+        client.init(
+            &initial_key,
+            &soroban_sdk::Bytes::new(&env),
+            &soroban_sdk::Bytes::new(&env),
+        );
+        client.set_recovery_key(&recovery_addr);
+        client.request_recovery(&new_key);
+
+        // One second before unlock.
+        advance_time(&env, RECOVERY_KEY_DELAY - 1);
+        assert!(client.try_finalize_recovery().is_err());
+
+        // Exactly at unlock_at (timestamp == unlock_at is still locked; need >).
+        advance_time(&env, 1);
+        assert!(client.try_finalize_recovery().is_err());
+
+        // One second past unlock.
+        advance_time(&env, 1);
+        client.finalize_recovery();
+    }
+
+    // ── cancellation ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_cancel_recovery_request() {
+        let (env, id) = setup();
+        let client = InvisibleWalletClient::new(&env, &id);
+
+        let recovery_addr = Address::generate(&env);
+        let initial_key = mock_key(&env, 0x01);
+        let new_key = mock_key(&env, 0x42);
+
+        client.init(
+            &initial_key,
+            &soroban_sdk::Bytes::new(&env),
+            &soroban_sdk::Bytes::new(&env),
+        );
+        client.set_recovery_key(&recovery_addr);
+        client.request_recovery(&new_key);
+        client.cancel_recovery_request();
+
+        // After cancellation finalize must fail.
+        advance_time(&env, RECOVERY_KEY_DELAY + 1);
+        assert!(
+            client.try_finalize_recovery().is_err(),
+            "finalize after cancel must fail"
+        );
+    }
+
+    #[test]
+    fn test_cancel_without_pending_fails() {
+        let (env, id) = setup();
+        let client = InvisibleWalletClient::new(&env, &id);
+        assert!(client.try_cancel_recovery_request().is_err());
+    }
+
+    // ── error paths ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_request_without_recovery_key_fails() {
+        let (env, id) = setup();
+        let client = InvisibleWalletClient::new(&env, &id);
+        let new_key = mock_key(&env, 0x42);
+        assert!(client.try_request_recovery(&new_key).is_err());
+    }
+
+    #[test]
+    fn test_duplicate_request_rejected() {
+        let (env, id) = setup();
+        let client = InvisibleWalletClient::new(&env, &id);
+
+        let recovery_addr = Address::generate(&env);
+        let initial_key = mock_key(&env, 0x01);
+        let key1 = mock_key(&env, 0x11);
+        let key2 = mock_key(&env, 0x22);
+
+        client.init(
+            &initial_key,
+            &soroban_sdk::Bytes::new(&env),
+            &soroban_sdk::Bytes::new(&env),
+        );
+        client.set_recovery_key(&recovery_addr);
+        client.request_recovery(&key1);
+
+        assert!(
+            client.try_request_recovery(&key2).is_err(),
+            "second request while one is pending must fail"
+        );
+    }
+
+    #[test]
+    fn test_finalize_without_pending_fails() {
+        let (env, id) = setup();
+        let client = InvisibleWalletClient::new(&env, &id);
+        assert!(client.try_finalize_recovery().is_err());
+    }
+}

--- a/contracts/invisible_wallet/src/storage.rs
+++ b/contracts/invisible_wallet/src/storage.rs
@@ -28,6 +28,10 @@ pub enum DataKey {
     Nonce,
     /// Granular spending limit for a spender and token.
     Allowance(AllowanceKey),
+    /// The designated recovery key address (Address).
+    RecoveryKey,
+    /// Stores a PendingRecovery struct while a recovery-key request is in progress.
+    RecoveryKeyPending,
 }
 
 #[contracttype]

--- a/contracts/invisible_wallet/src/storage/tests.rs
+++ b/contracts/invisible_wallet/src/storage/tests.rs
@@ -20,6 +20,8 @@ fn _cover_all_variants(key: &DataKey) {
         DataKey::RecoveryPending => (),
         DataKey::Nonce => (),
         DataKey::Allowance(_) => (),
+        DataKey::RecoveryKey => (),
+        DataKey::RecoveryKeyPending => (),
     };
 }
 

--- a/contracts/invisible_wallet/test_snapshots/policies/spend_limit/tests/cumulative_over_cap_rejected.1.json
+++ b/contracts/invisible_wallet/test_snapshots/policies/spend_limit/tests/cumulative_over_cap_rejected.1.json
@@ -1,0 +1,152 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Limit"
+                },
+                {
+                  "bytes": "0505050505050505050505050505050505050505050505050505050505050505050505050505050505050505050505050505050505050505050505050505050505"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Limit"
+                    },
+                    {
+                      "bytes": "0505050505050505050505050505050505050505050505050505050505050505050505050505050505050505050505050505050505050505050505050505050505"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "cap"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 1000
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "window_spent"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 1000
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "window_start"
+                      },
+                      "val": {
+                        "u64": 0
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/invisible_wallet/test_snapshots/policies/spend_limit/tests/exactly_at_cap_passes.1.json
+++ b/contracts/invisible_wallet/test_snapshots/policies/spend_limit/tests/exactly_at_cap_passes.1.json
@@ -1,0 +1,152 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Limit"
+                },
+                {
+                  "bytes": "0303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Limit"
+                    },
+                    {
+                      "bytes": "0303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "cap"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 1000
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "window_spent"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 1000
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "window_start"
+                      },
+                      "val": {
+                        "u64": 0
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/invisible_wallet/test_snapshots/policies/spend_limit/tests/no_limit_always_passes.1.json
+++ b/contracts/invisible_wallet/test_snapshots/policies/spend_limit/tests/no_limit_always_passes.1.json
@@ -1,0 +1,76 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/invisible_wallet/test_snapshots/policies/spend_limit/tests/over_cap_rejected.1.json
+++ b/contracts/invisible_wallet/test_snapshots/policies/spend_limit/tests/over_cap_rejected.1.json
@@ -1,0 +1,152 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Limit"
+                },
+                {
+                  "bytes": "0404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Limit"
+                    },
+                    {
+                      "bytes": "0404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "cap"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 1000
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "window_spent"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 0
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "window_start"
+                      },
+                      "val": {
+                        "u64": 0
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/invisible_wallet/test_snapshots/policies/spend_limit/tests/remove_clears_limit.1.json
+++ b/contracts/invisible_wallet/test_snapshots/policies/spend_limit/tests/remove_clears_limit.1.json
@@ -1,0 +1,76 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/invisible_wallet/test_snapshots/policies/spend_limit/tests/spent_persists_across_calls.1.json
+++ b/contracts/invisible_wallet/test_snapshots/policies/spend_limit/tests/spent_persists_across_calls.1.json
@@ -1,0 +1,152 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Limit"
+                },
+                {
+                  "bytes": "0808080808080808080808080808080808080808080808080808080808080808080808080808080808080808080808080808080808080808080808080808080808"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Limit"
+                    },
+                    {
+                      "bytes": "0808080808080808080808080808080808080808080808080808080808080808080808080808080808080808080808080808080808080808080808080808080808"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "cap"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 300
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "window_spent"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 300
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "window_start"
+                      },
+                      "val": {
+                        "u64": 0
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/invisible_wallet/test_snapshots/policies/spend_limit/tests/window_not_reset_before_24h.1.json
+++ b/contracts/invisible_wallet/test_snapshots/policies/spend_limit/tests/window_not_reset_before_24h.1.json
@@ -1,0 +1,152 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 86399,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Limit"
+                },
+                {
+                  "bytes": "0707070707070707070707070707070707070707070707070707070707070707070707070707070707070707070707070707070707070707070707070707070707"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Limit"
+                    },
+                    {
+                      "bytes": "0707070707070707070707070707070707070707070707070707070707070707070707070707070707070707070707070707070707070707070707070707070707"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "cap"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 1000
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "window_spent"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 1000
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "window_start"
+                      },
+                      "val": {
+                        "u64": 0
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/invisible_wallet/test_snapshots/policies/spend_limit/tests/window_resets_after_24h.1.json
+++ b/contracts/invisible_wallet/test_snapshots/policies/spend_limit/tests/window_resets_after_24h.1.json
@@ -1,0 +1,152 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 86400,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Limit"
+                },
+                {
+                  "bytes": "0606060606060606060606060606060606060606060606060606060606060606060606060606060606060606060606060606060606060606060606060606060606"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Limit"
+                    },
+                    {
+                      "bytes": "0606060606060606060606060606060606060606060606060606060606060606060606060606060606060606060606060606060606060606060606060606060606"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "cap"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 1000
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "window_spent"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 1000
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "window_start"
+                      },
+                      "val": {
+                        "u64": 86400
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/invisible_wallet/test_snapshots/policies/spend_limit/tests/within_cap_passes.1.json
+++ b/contracts/invisible_wallet/test_snapshots/policies/spend_limit/tests/within_cap_passes.1.json
@@ -1,0 +1,152 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Limit"
+                },
+                {
+                  "bytes": "0202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Limit"
+                    },
+                    {
+                      "bytes": "0202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "cap"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 1000
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "window_spent"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 1000
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "window_start"
+                      },
+                      "val": {
+                        "u64": 0
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}


### PR DESCRIPTION
## Summary

- Adds `contracts/invisible_wallet/src/policies/spend_limit.rs` with a rolling 24-hour window spend cap per WebAuthn signer key
- Storage record `SpendWindow { cap, window_start, window_spent }` keyed by signer public key (`BytesN<65>`) in persistent storage
- `__check_auth` Branch 3 (WebAuthn) now sums all auth-context amounts and enforces the cap; window auto-resets when `now >= window_start + 86_400s`
- New public entry-points: `set_key_spend_limit`, `remove_key_spend_limit`, `get_key_spend_limit`
- New error variant: `WalletError::SpendLimitExceeded = 22`

## Changes

| File | Change |
|---|---|
| `contracts/invisible_wallet/src/lib.rs` | `pub mod policies`, `SpendLimitExceeded` error, `enforce` call in `__check_auth`, 3 public fns |
| `contracts/invisible_wallet/src/policies/mod.rs` | new — module entry |
| `contracts/invisible_wallet/src/policies/spend_limit.rs` | new — full implementation + 9 unit tests |
| `test_snapshots/policies/spend_limit/tests/*.json` | new — SDK ledger snapshots for each test |

## Verification

```
RUSTUP_TOOLCHAIN=stable cargo test -p invisible-wallet
running 72 tests
...
test result: ok. 72 passed; 0 failed
```

All 9 spend_limit tests:
- `no_limit_always_passes` — uncapped key passes any amount
- `within_cap_passes` — cumulative spend within cap passes
- `exactly_at_cap_passes` — boundary: exactly at cap passes
- `over_cap_rejected` — single call over cap returns `SpendLimitExceeded`
- `cumulative_over_cap_rejected` — multi-call cumulative enforcement
- `window_resets_after_24h` — at `window_start + 86_400s` window resets
- `window_not_reset_before_24h` — 1 s before reset: still blocked
- `spent_persists_across_calls` — running total correct across calls
- `remove_clears_limit` — after remove, any amount passes

closes #235