### PR TITLE
feat(invisible-wallet): add recovery-key flow with 7-day timelock

### DIFF
--- a/contracts/invisible_wallet/src/lib.rs
+++ b/contracts/invisible_wallet/src/lib.rs
@@ -8,9 +8,12 @@ use soroban_sdk::{
 
 mod auth;
 mod storage;
+mod recovery;
 pub mod session_key;
 #[cfg(test)]
 mod auth_failure_tests;
+#[cfg(test)]
+mod guardian_test;
 use storage::{DataKey, AllowanceKey, PendingRecovery};
 
 /// Recovery timelock duration: 3 days in seconds.
@@ -56,6 +59,8 @@ pub enum WalletError {
     SessionKeyExpired           = 19,
     /// A session key call violates its ACL (wrong target, selector, or cumulative budget exceeded).
     SessionKeyAclViolation      = 20,
+    /// No recovery key is set on this wallet.
+    NoRecoveryKeySet            = 21,
 }
 
 #[contract]
@@ -558,6 +563,53 @@ impl InvisibleWallet {
     pub fn revoke_session_key(env: Env, key_id: BytesN<32>) {
         env.current_contract_address().require_auth();
         session_key::revoke(&env, &key_id);
+    }
+
+    /// Register a designated recovery key for this wallet.
+    ///
+    /// The recovery key is an Address (e.g. a cold-wallet account) that is
+    /// authorized to initiate signer rotation via `request_recovery`.
+    /// Requires current wallet signer authorization.
+    pub fn set_recovery_key(env: Env, key: Address) {
+        env.current_contract_address().require_auth();
+        recovery::set_recovery_key(&env, &key);
+    }
+
+    /// Start a 7-day recovery cooldown to replace the active signer.
+    ///
+    /// Only the designated recovery key (set via `set_recovery_key`) may call
+    /// this. After the 7-day timelock expires, anyone can call `finalize_recovery`
+    /// to complete the rotation.
+    ///
+    /// # Errors
+    /// * `NoRecoveryKeySet`       — no recovery key has been registered.
+    /// * `RecoveryAlreadyPending` — a recovery request is already in progress.
+    pub fn request_recovery(env: Env, new_signer: BytesN<65>) -> Result<(), WalletError> {
+        recovery::request_recovery(&env, new_signer)
+    }
+
+    /// Finalize a pending recovery request after the 7-day timelock has expired.
+    ///
+    /// Permissionless — anyone may call this once `ledger.timestamp > unlock_at`.
+    ///
+    /// # Errors
+    /// * `RecoveryNotPending`     — no recovery request is in progress.
+    /// * `RecoveryTimelockActive` — the 7-day cooldown has not yet elapsed.
+    pub fn finalize_recovery(env: Env) -> Result<(), WalletError> {
+        recovery::finalize_recovery(&env)
+    }
+
+    /// Cancel a pending recovery-key request.
+    ///
+    /// Only the current wallet signer (the contract itself) may cancel.
+    /// This lets a wallet owner who still holds their key abort a recovery
+    /// attempt before it is finalized.
+    ///
+    /// # Errors
+    /// * `RecoveryNotPending` — no recovery request is in progress.
+    pub fn cancel_recovery_request(env: Env) -> Result<(), WalletError> {
+        env.current_contract_address().require_auth();
+        recovery::cancel_recovery_request(&env)
     }
 }
 

--- a/contracts/invisible_wallet/src/recovery.rs
+++ b/contracts/invisible_wallet/src/recovery.rs
@@ -1,0 +1,262 @@
+use soroban_sdk::{symbol_short, Address, BytesN, Env};
+
+use crate::storage::{DataKey, PendingRecovery};
+use crate::WalletError;
+
+/// 7-day timelock in seconds.
+pub const RECOVERY_KEY_DELAY: u64 = 604_800;
+
+pub fn set_recovery_key(env: &Env, key: &Address) {
+    env.storage().persistent().set(&DataKey::RecoveryKey, key);
+    env.events().publish(
+        (symbol_short!("rec_key"), symbol_short!("set")),
+        key.clone(),
+    );
+}
+
+pub fn request_recovery(env: &Env, new_signer: BytesN<65>) -> Result<(), WalletError> {
+    let recovery_key: Address = env
+        .storage()
+        .persistent()
+        .get(&DataKey::RecoveryKey)
+        .ok_or(WalletError::NoRecoveryKeySet)?;
+
+    recovery_key.require_auth();
+
+    if env.storage().persistent().has(&DataKey::RecoveryKeyPending) {
+        return Err(WalletError::RecoveryAlreadyPending);
+    }
+
+    let unlock_at = env.ledger().timestamp() + RECOVERY_KEY_DELAY;
+    let pending = PendingRecovery {
+        new_public_key: new_signer.clone(),
+        recovery_unlock_time: unlock_at,
+    };
+    env.storage()
+        .persistent()
+        .set(&DataKey::RecoveryKeyPending, &pending);
+
+    env.events().publish(
+        (symbol_short!("rec_key"), symbol_short!("request")),
+        (new_signer, unlock_at),
+    );
+
+    Ok(())
+}
+
+pub fn finalize_recovery(env: &Env) -> Result<(), WalletError> {
+    let pending: PendingRecovery = env
+        .storage()
+        .persistent()
+        .get(&DataKey::RecoveryKeyPending)
+        .ok_or(WalletError::RecoveryNotPending)?;
+
+    if env.ledger().timestamp() <= pending.recovery_unlock_time {
+        return Err(WalletError::RecoveryTimelockActive);
+    }
+
+    crate::storage::init_signers(env, &pending.new_public_key);
+    env.storage()
+        .persistent()
+        .remove(&DataKey::RecoveryKeyPending);
+
+    env.events().publish(
+        (symbol_short!("rec_key"), symbol_short!("done")),
+        pending.new_public_key,
+    );
+
+    Ok(())
+}
+
+/// Cancel a pending recovery-key request. Requires current signer (contract) auth.
+pub fn cancel_recovery_request(env: &Env) -> Result<(), WalletError> {
+    if !env
+        .storage()
+        .persistent()
+        .has(&DataKey::RecoveryKeyPending)
+    {
+        return Err(WalletError::RecoveryNotPending);
+    }
+
+    env.storage()
+        .persistent()
+        .remove(&DataKey::RecoveryKeyPending);
+
+    env.events().publish(
+        (symbol_short!("rec_key"), symbol_short!("cancel")),
+        (),
+    );
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::testutils::{Address as _, Ledger, LedgerInfo};
+    use soroban_sdk::{Address, BytesN, Env};
+
+    use crate::{InvisibleWallet, InvisibleWalletClient};
+
+    fn setup() -> (Env, Address) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register_contract(None, InvisibleWallet);
+        (env, id)
+    }
+
+    fn mock_key(env: &Env, seed: u8) -> BytesN<65> {
+        let mut b = [0u8; 65];
+        b[0] = 0x04;
+        b[1] = seed;
+        BytesN::from_array(env, &b)
+    }
+
+    fn advance_time(env: &Env, secs: u64) {
+        let mut info: LedgerInfo = env.ledger().get();
+        info.timestamp += secs;
+        env.ledger().set(info);
+    }
+
+    // ── happy path ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_request_and_finalize_recovery() {
+        let (env, id) = setup();
+        let client = InvisibleWalletClient::new(&env, &id);
+
+        let recovery_addr = Address::generate(&env);
+        let initial_key = mock_key(&env, 0x01);
+        let new_key = mock_key(&env, 0x42);
+
+        client.init(
+            &initial_key,
+            &soroban_sdk::Bytes::new(&env),
+            &soroban_sdk::Bytes::new(&env),
+        );
+        client.set_recovery_key(&recovery_addr);
+        client.request_recovery(&new_key);
+
+        // Cannot finalize before timelock expires.
+        assert!(
+            client.try_finalize_recovery().is_err(),
+            "finalize before cooldown must fail"
+        );
+
+        advance_time(&env, RECOVERY_KEY_DELAY + 1);
+        client.finalize_recovery();
+
+        assert!(
+            client.has_signer(&new_key),
+            "new signer must be registered after finalize"
+        );
+    }
+
+    // ── timelock boundary ───────────────────────────────────────────────────────
+
+    #[test]
+    fn test_timelock_boundary() {
+        let (env, id) = setup();
+        let client = InvisibleWalletClient::new(&env, &id);
+
+        let recovery_addr = Address::generate(&env);
+        let initial_key = mock_key(&env, 0x01);
+        let new_key = mock_key(&env, 0x42);
+
+        client.init(
+            &initial_key,
+            &soroban_sdk::Bytes::new(&env),
+            &soroban_sdk::Bytes::new(&env),
+        );
+        client.set_recovery_key(&recovery_addr);
+        client.request_recovery(&new_key);
+
+        // One second before unlock.
+        advance_time(&env, RECOVERY_KEY_DELAY - 1);
+        assert!(client.try_finalize_recovery().is_err());
+
+        // Exactly at unlock_at (timestamp == unlock_at is still locked; need >).
+        advance_time(&env, 1);
+        assert!(client.try_finalize_recovery().is_err());
+
+        // One second past unlock.
+        advance_time(&env, 1);
+        client.finalize_recovery();
+    }
+
+    // ── cancellation ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_cancel_recovery_request() {
+        let (env, id) = setup();
+        let client = InvisibleWalletClient::new(&env, &id);
+
+        let recovery_addr = Address::generate(&env);
+        let initial_key = mock_key(&env, 0x01);
+        let new_key = mock_key(&env, 0x42);
+
+        client.init(
+            &initial_key,
+            &soroban_sdk::Bytes::new(&env),
+            &soroban_sdk::Bytes::new(&env),
+        );
+        client.set_recovery_key(&recovery_addr);
+        client.request_recovery(&new_key);
+        client.cancel_recovery_request();
+
+        // After cancellation finalize must fail.
+        advance_time(&env, RECOVERY_KEY_DELAY + 1);
+        assert!(
+            client.try_finalize_recovery().is_err(),
+            "finalize after cancel must fail"
+        );
+    }
+
+    #[test]
+    fn test_cancel_without_pending_fails() {
+        let (env, id) = setup();
+        let client = InvisibleWalletClient::new(&env, &id);
+        assert!(client.try_cancel_recovery_request().is_err());
+    }
+
+    // ── error paths ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_request_without_recovery_key_fails() {
+        let (env, id) = setup();
+        let client = InvisibleWalletClient::new(&env, &id);
+        let new_key = mock_key(&env, 0x42);
+        assert!(client.try_request_recovery(&new_key).is_err());
+    }
+
+    #[test]
+    fn test_duplicate_request_rejected() {
+        let (env, id) = setup();
+        let client = InvisibleWalletClient::new(&env, &id);
+
+        let recovery_addr = Address::generate(&env);
+        let initial_key = mock_key(&env, 0x01);
+        let key1 = mock_key(&env, 0x11);
+        let key2 = mock_key(&env, 0x22);
+
+        client.init(
+            &initial_key,
+            &soroban_sdk::Bytes::new(&env),
+            &soroban_sdk::Bytes::new(&env),
+        );
+        client.set_recovery_key(&recovery_addr);
+        client.request_recovery(&key1);
+
+        assert!(
+            client.try_request_recovery(&key2).is_err(),
+            "second request while one is pending must fail"
+        );
+    }
+
+    #[test]
+    fn test_finalize_without_pending_fails() {
+        let (env, id) = setup();
+        let client = InvisibleWalletClient::new(&env, &id);
+        assert!(client.try_finalize_recovery().is_err());
+    }
+}

--- a/contracts/invisible_wallet/src/storage.rs
+++ b/contracts/invisible_wallet/src/storage.rs
@@ -28,6 +28,10 @@ pub enum DataKey {
     Nonce,
     /// Granular spending limit for a spender and token.
     Allowance(AllowanceKey),
+    /// The designated recovery key address (Address).
+    RecoveryKey,
+    /// Stores a PendingRecovery struct while a recovery-key request is in progress.
+    RecoveryKeyPending,
 }
 
 #[contracttype]

--- a/contracts/invisible_wallet/src/storage/tests.rs
+++ b/contracts/invisible_wallet/src/storage/tests.rs
@@ -20,6 +20,8 @@ fn _cover_all_variants(key: &DataKey) {
         DataKey::RecoveryPending => (),
         DataKey::Nonce => (),
         DataKey::Allowance(_) => (),
+        DataKey::RecoveryKey => (),
+        DataKey::RecoveryKeyPending => (),
     };
 }
 


### PR DESCRIPTION
## Summary

- Adds `set_recovery_key` — wallet owner registers a cold-wallet `Address` as a dedicated recovery key
- Adds `request_recovery` — recovery key starts a 7-day timelock (604 800 s) to rotate the signer
- Adds `finalize_recovery` — permissionless; callable once `ledger.timestamp > unlock_at`
- Adds `cancel_recovery_request` — current signer can abort a pending request before it finalizes
- Adds `DataKey::RecoveryKey` / `RecoveryKeyPending` storage variants and `WalletError::NoRecoveryKeySet`
- Recovery logic isolated in a new `contracts/invisible_wallet/src/recovery.rs` module

## Changes

**New file:** `contracts/invisible_wallet/src/recovery.rs`  
**Modified:** `lib.rs`, `storage.rs`, `storage/tests.rs`

The recovery-key path is independent from the existing guardian recovery (`initiate_recovery` / `complete_recovery`). A wallet can have both set simultaneously.

Timelock uses strictly-greater check (`timestamp > unlock_at`) as specified in the issue.

The previously orphaned `guardian_test` module is now wired into `lib.rs` so the 6 guardian-recovery tests run with `cargo test`.

## Verification

`cargo test` (stable toolchain) — **63 passed, 0 failed**

New tests:
- `recovery::tests::test_request_and_finalize_recovery` — happy path
- `recovery::tests::test_timelock_boundary` — boundary: passes only when `timestamp > unlock_at`
- `recovery::tests::test_cancel_recovery_request` — cancel then finalize fails
- `recovery::tests::test_cancel_without_pending_fails` — error path
- `recovery::tests::test_request_without_recovery_key_fails` — error path
- `recovery::tests::test_duplicate_request_rejected` — error path
- `recovery::tests::test_finalize_without_pending_fails` — error path

closes #236