### PR TITLE
feat(wallet): add dedicated passkeys settings page

### DIFF
--- a/frontend/wallet/app/settings/page.tsx
+++ b/frontend/wallet/app/settings/page.tsx
@@ -380,17 +380,17 @@ export default function SettingsPage() {
                 </p>
               </div>
 
-              {/* Add signer card */}
+              {/* Passkeys card */}
               <button
                 className="card"
-                onClick={() => { setSection('add-signer'); setStatus(null) }}
+                onClick={() => router.push('/settings/passkeys')}
                 style={{ textAlign: 'left', cursor: 'pointer', width: '100%', border: '1px solid var(--border-dim)', background: 'var(--surface)' }}
               >
                 <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
                   <div>
-                    <p style={{ fontWeight: 500, fontSize: '0.9375rem' }}>Add signer</p>
+                    <p style={{ fontWeight: 500, fontSize: '0.9375rem' }}>Passkeys</p>
                     <p style={{ fontSize: '0.8125rem', color: 'rgba(246,247,248,0.4)', marginTop: '0.25rem' }}>
-                      Register a second device with a new passkey
+                      View and manage passkeys registered on this wallet
                     </p>
                   </div>
                   <svg width="16" height="16" viewBox="0 0 16 16" fill="none" style={{ flexShrink: 0 }}>

--- a/frontend/wallet/app/settings/passkeys/page.tsx
+++ b/frontend/wallet/app/settings/passkeys/page.tsx
@@ -1,0 +1,217 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import { useRouter } from 'next/navigation'
+import { Keypair } from '@stellar/stellar-sdk'
+import { ChevronLeft, KeyRound, Plus, Trash2 } from 'lucide-react'
+import { useInvisibleWallet, type SignerInfo } from '@veil/sdk'
+import { walletConfig } from '@/lib/network'
+import { useInactivityLock } from '@/hooks/useInactivityLock'
+
+export default function PasskeysPage() {
+  const router = useRouter()
+  useInactivityLock()
+
+  const [signers, setSigners] = useState<SignerInfo[]>([])
+  const [localPublicKey, setLocalPublicKey] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [status, setStatus] = useState<{ text: string; ok: boolean } | null>(null)
+
+  const wallet = useInvisibleWallet(walletConfig)
+
+  function getSignerKeypair(): Keypair {
+    const secret = sessionStorage.getItem('veil_signer_secret')
+    if (!secret) throw new Error('No signer key in session')
+    return Keypair.fromSecret(secret)
+  }
+
+  const fetchSigners = useCallback(async () => {
+    try {
+      const list = await wallet.getSigners()
+      setSigners(list)
+    } catch (e) {
+      console.error('Failed to fetch signers', e)
+    }
+  }, [wallet.getSigners])
+
+  useEffect(() => {
+    const addr = sessionStorage.getItem('invisible_wallet_address')
+    if (!addr) { router.replace('/lock'); return }
+    fetchSigners()
+    if (typeof window !== 'undefined') {
+      setLocalPublicKey(localStorage.getItem('invisible_wallet_public_key'))
+    }
+  }, [router, fetchSigners])
+
+  async function handleAddPasskey() {
+    setLoading(true)
+    setStatus(null)
+    try {
+      const signerKeypair = getSignerKeypair()
+      const result = await wallet.register()
+      if (!result?.publicKeyBytes) throw new Error('Registration returned no public key')
+      const res = await wallet.addSigner(signerKeypair, result.publicKeyBytes)
+      setStatus({ text: `New passkey added at index ${res.signerIndex}`, ok: true })
+      await fetchSigners()
+    } catch (err: unknown) {
+      setStatus({ text: err instanceof Error ? err.message : String(err), ok: false })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function handleRemovePasskey(index: number) {
+    if (signers.length <= 1) return
+    setLoading(true)
+    setStatus(null)
+    try {
+      const signerKeypair = getSignerKeypair()
+      await wallet.removeSigner(signerKeypair, index)
+      setStatus({ text: `Passkey #${index} removed`, ok: true })
+      await fetchSigners()
+    } catch (err: unknown) {
+      setStatus({ text: err instanceof Error ? err.message : String(err), ok: false })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const chevronRight = (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" style={{ flexShrink: 0 }}>
+      <path d="M6 3l5 5-5 5" stroke="rgba(246,247,248,0.3)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  )
+  void chevronRight
+
+  return (
+    <div className="wallet-shell" style={{ padding: '1.5rem 1.25rem 4rem' }}>
+      <div style={{ maxWidth: 480, width: '100%', margin: '0 auto' }}>
+        {/* Header */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', marginBottom: '1.75rem' }}>
+          <button
+            type="button"
+            onClick={() => router.push('/settings')}
+            aria-label="Back to settings"
+            style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--off-white)', display: 'flex', padding: 0 }}
+          >
+            <ChevronLeft size={22} strokeWidth={1.75} />
+          </button>
+          <h1 style={{ fontFamily: 'Lora, Georgia, serif', fontWeight: 600, fontStyle: 'italic', fontSize: '1.375rem', color: 'var(--off-white)' }}>
+            Passkeys
+          </h1>
+        </div>
+
+        <p style={{ fontSize: '0.875rem', color: 'rgba(246,247,248,0.4)', marginBottom: '1.75rem', lineHeight: 1.6 }}>
+          Each passkey is a separate device credential. Adding a second passkey on a backup laptop or phone lets you recover access if one device is lost.
+        </p>
+
+        {/* Section label */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.625rem', marginBottom: '0.625rem' }}>
+          <KeyRound size={16} color="var(--gold)" strokeWidth={1.75} />
+          <p style={{ fontFamily: 'Anton, Impact, sans-serif', letterSpacing: '0.06em', fontSize: '0.75rem', color: 'rgba(246,247,248,0.5)' }}>
+            REGISTERED PASSKEYS
+          </p>
+        </div>
+
+        {/* Signers list */}
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '0.625rem', marginBottom: '1.5rem' }}>
+          {signers.length === 0 && (
+            <div className="card-md" style={{ textAlign: 'center', padding: '1.5rem' }}>
+              <p style={{ fontSize: '0.875rem', color: 'rgba(246,247,248,0.3)' }}>Loading passkeys…</p>
+            </div>
+          )}
+
+          {signers.map((s) => {
+            const isThisDevice = localPublicKey === s.publicKey
+            const truncated = `0x${s.publicKey.slice(0, 12)}…${s.publicKey.slice(-8)}`
+            const canRemove = signers.length > 1
+
+            return (
+              <div
+                key={s.index}
+                className="card-md"
+                style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '0.75rem' }}
+              >
+                <div style={{ minWidth: 0 }}>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                    <p style={{ fontSize: '0.8125rem', fontWeight: 600, color: 'var(--off-white)' }}>
+                      #{s.index}
+                    </p>
+                    {isThisDevice && (
+                      <span style={{
+                        fontSize: '0.625rem',
+                        background: 'rgba(94, 234, 212, 0.1)',
+                        color: 'var(--teal)',
+                        padding: '0.125rem 0.375rem',
+                        borderRadius: '4px',
+                        textTransform: 'uppercase',
+                        letterSpacing: '0.02em',
+                        flexShrink: 0,
+                      }}>
+                        This device
+                      </span>
+                    )}
+                  </div>
+                  <p style={{ fontFamily: 'Inconsolata, monospace', fontSize: '0.75rem', color: 'rgba(246,247,248,0.4)', marginTop: '0.25rem', wordBreak: 'break-all' }}>
+                    {truncated}
+                  </p>
+                </div>
+
+                <button
+                  type="button"
+                  onClick={() => handleRemovePasskey(s.index)}
+                  disabled={loading || !canRemove}
+                  aria-label={`Remove passkey #${s.index}`}
+                  title={canRemove ? `Remove passkey #${s.index}` : 'Cannot remove the last passkey'}
+                  style={{
+                    background: 'none',
+                    border: 'none',
+                    cursor: canRemove ? 'pointer' : 'not-allowed',
+                    color: canRemove ? 'rgba(220,38,38,0.8)' : 'rgba(246,247,248,0.1)',
+                    display: 'flex',
+                    alignItems: 'center',
+                    flexShrink: 0,
+                    padding: '0.25rem',
+                  }}
+                >
+                  <Trash2 size={16} strokeWidth={1.75} />
+                </button>
+              </div>
+            )
+          })}
+        </div>
+
+        {/* Status */}
+        {status && (
+          <div className="card-md" style={{ marginBottom: '1rem', borderLeft: `3px solid ${status.ok ? 'var(--teal)' : 'rgba(220,38,38,0.6)'}` }}>
+            <p style={{ fontSize: '0.875rem', color: status.ok ? 'var(--teal)' : 'rgba(220,38,38,0.9)' }}>
+              {status.text}
+            </p>
+          </div>
+        )}
+
+        {/* Add passkey button */}
+        <button
+          type="button"
+          className="btn-gold"
+          onClick={handleAddPasskey}
+          disabled={loading}
+          style={{ width: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '0.5rem' }}
+        >
+          {loading ? (
+            <span className="spinner" />
+          ) : (
+            <>
+              <Plus size={16} strokeWidth={2} />
+              Add passkey
+            </>
+          )}
+        </button>
+
+        <p style={{ fontSize: '0.75rem', color: 'rgba(246,247,248,0.3)', marginTop: '0.875rem', lineHeight: 1.5 }}>
+          Adding a passkey prompts a new biometric registration on this device. The new credential is stored on-chain alongside existing ones.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/sdk/src/__tests__/useInvisibleWallet.test.ts
+++ b/sdk/src/__tests__/useInvisibleWallet.test.ts
@@ -8,7 +8,7 @@
 
 import { renderHook, act } from '@testing-library/react'
 import { useInvisibleWallet } from '../useInvisibleWallet'
-import { rpc as SorobanRpc, TransactionBuilder } from '@stellar/stellar-sdk'
+import { rpc as SorobanRpc, TransactionBuilder, Keypair } from '@stellar/stellar-sdk'
 
 // ── @stellar/stellar-sdk mock ─────────────────────────────────────────────────
 
@@ -30,6 +30,11 @@ jest.mock('@stellar/stellar-sdk', () => ({
       }),
       sendTransaction: jest.fn().mockResolvedValue({ status: 'PENDING', hash: 'mock-hash' }),
       getTransaction:  jest.fn().mockResolvedValue({ status: 'SUCCESS' }),
+      getAccount:      jest.fn().mockResolvedValue({
+        accountId: () => 'GPUBKEY',
+        sequenceNumber: () => '0',
+        incrementSequenceNumber: jest.fn(),
+      }),
     })),
     Api: {
       GetTransactionStatus: { SUCCESS: 'SUCCESS', NOT_FOUND: 'NOT_FOUND', FAILED: 'FAILED' },
@@ -405,6 +410,130 @@ describe('useInvisibleWallet', () => {
       const { result } = renderHook(() => useInvisibleWallet(CONFIG))
       expect(result.current.isPending).toBe(false)
       expect(result.current.error).toBeNull()
+    })
+  })
+
+  describe('addSigner()', () => {
+    it('submits add_signer and returns signerIndex decoded from tx returnValue', async () => {
+      localStorage.setItem('invisible_wallet_address', 'CWALLET')
+      const { result } = renderHook(() => useInvisibleWallet(CONFIG))
+
+      // Make scValToNative return index 2 for this call
+      ;(SorobanRpc.Server as jest.Mock).mockImplementationOnce(() => ({
+        getAccount:      jest.fn().mockResolvedValue({ accountId: () => 'G', sequenceNumber: () => '0', incrementSequenceNumber: jest.fn() }),
+        simulateTransaction: jest.fn().mockResolvedValue({ result: { retval: {} }, minResourceFee: '0', transactionData: {}, events: [], latestLedger: 1 }),
+        sendTransaction: jest.fn().mockResolvedValue({ status: 'PENDING', hash: 'add-hash' }),
+        getTransaction:  jest.fn().mockResolvedValue({ status: 'SUCCESS', returnValue: { _type: 'u32', _value: 2 } }),
+      }))
+
+      const { scValToNative } = jest.requireMock('@stellar/stellar-sdk') as typeof import('@stellar/stellar-sdk')
+      ;(scValToNative as jest.Mock).mockReturnValueOnce(2)
+
+      const fakeKeypair = Keypair.fromSecret('SSECRET')
+      const newKey = new Uint8Array(65).fill(4)
+
+      let res!: Awaited<ReturnType<typeof result.current.addSigner>>
+      await act(async () => {
+        res = await result.current.addSigner(fakeKeypair, newKey)
+      })
+
+      expect(res.signerIndex).toBe(2)
+    })
+
+    it('throws when newPublicKeyBytes is not 65 bytes', async () => {
+      localStorage.setItem('invisible_wallet_address', 'CWALLET')
+      const { result } = renderHook(() => useInvisibleWallet(CONFIG))
+
+      await act(async () => {
+        await expect(
+          result.current.addSigner(Keypair.fromSecret('SSECRET'), new Uint8Array(32))
+        ).rejects.toThrow('newPublicKeyBytes must be exactly 65 bytes')
+      })
+    })
+
+    it('throws when no wallet address is set', async () => {
+      localStorage.removeItem('invisible_wallet_address')
+      const { result } = renderHook(() => useInvisibleWallet(CONFIG))
+
+      await act(async () => {
+        await expect(
+          result.current.addSigner(Keypair.fromSecret('SSECRET'), new Uint8Array(65))
+        ).rejects.toThrow('No wallet address')
+      })
+    })
+  })
+
+  describe('removeSigner()', () => {
+    it('submits remove_signer and resolves on success', async () => {
+      localStorage.setItem('invisible_wallet_address', 'CWALLET')
+
+      ;(SorobanRpc.Server as jest.Mock).mockImplementationOnce(() => ({
+        getAccount:          jest.fn().mockResolvedValue({ accountId: () => 'G', sequenceNumber: () => '0', incrementSequenceNumber: jest.fn() }),
+        simulateTransaction: jest.fn().mockResolvedValue({ result: { retval: {} }, minResourceFee: '0', transactionData: {}, events: [], latestLedger: 1 }),
+        sendTransaction:     jest.fn().mockResolvedValue({ status: 'PENDING', hash: 'rm-hash' }),
+        getTransaction:      jest.fn().mockResolvedValue({ status: 'SUCCESS' }),
+      }))
+
+      const { result } = renderHook(() => useInvisibleWallet(CONFIG))
+
+      await act(async () => {
+        await expect(
+          result.current.removeSigner(Keypair.fromSecret('SSECRET'), 1)
+        ).resolves.toBeUndefined()
+      })
+    })
+
+    it('throws when no wallet address is set', async () => {
+      localStorage.removeItem('invisible_wallet_address')
+      const { result } = renderHook(() => useInvisibleWallet(CONFIG))
+
+      await act(async () => {
+        await expect(
+          result.current.removeSigner(Keypair.fromSecret('SSECRET'), 0)
+        ).rejects.toThrow('No wallet address')
+      })
+    })
+  })
+
+  describe('getSigners()', () => {
+    it('returns SignerInfo array sorted by index', async () => {
+      localStorage.setItem('invisible_wallet_address', 'CWALLET')
+
+      // Simulate a Map returned by scValToNative via the object-entries fallback path
+      const fakeSignersObj: Record<string, Uint8Array> = {
+        '1': new Uint8Array(65).fill(9),
+        '0': new Uint8Array(65).fill(4),
+      }
+
+      ;(SorobanRpc.Server as jest.Mock).mockImplementationOnce(() => ({
+        getAccount:          jest.fn().mockResolvedValue({ accountId: () => 'G', sequenceNumber: () => '0', incrementSequenceNumber: jest.fn() }),
+        simulateTransaction: jest.fn().mockResolvedValue({ result: { retval: { _fake: true } }, minResourceFee: '0', transactionData: {}, events: [], latestLedger: 1 }),
+        sendTransaction:     jest.fn().mockResolvedValue({ status: 'PENDING', hash: 'sig-hash' }),
+        getTransaction:      jest.fn().mockResolvedValue({ status: 'SUCCESS' }),
+      }))
+
+      const { scValToNative } = jest.requireMock('@stellar/stellar-sdk') as typeof import('@stellar/stellar-sdk')
+      ;(scValToNative as jest.Mock).mockReturnValueOnce(fakeSignersObj)
+
+      const { result } = renderHook(() => useInvisibleWallet(CONFIG))
+
+      let signers!: Awaited<ReturnType<typeof result.current.getSigners>>
+      await act(async () => {
+        signers = await result.current.getSigners()
+      })
+
+      expect(signers).toHaveLength(2)
+      expect(signers[0].index).toBe(0)
+      expect(signers[1].index).toBe(1)
+    })
+
+    it('throws when no wallet address is set', async () => {
+      localStorage.removeItem('invisible_wallet_address')
+      const { result } = renderHook(() => useInvisibleWallet(CONFIG))
+
+      await act(async () => {
+        await expect(result.current.getSigners()).rejects.toThrow('No wallet address')
+      })
     })
   })
 })


### PR DESCRIPTION
## Summary

- Adds `frontend/wallet/app/settings/passkeys/page.tsx` — a dedicated route listing all registered passkeys on the wallet, with **Add passkey** and **Remove** buttons
- The page shows a "This device" badge next to the key whose public key matches local storage, and disables Remove when only one passkey remains (mirroring the on-chain guard)
- Updates `frontend/wallet/app/settings/page.tsx` to replace the inline add-signer section with a nav card that routes to `/settings/passkeys`
- Adds SDK unit tests for `addSigner`, `removeSigner`, and `getSigners` covering the happy path and error cases (wrong key length, missing wallet address)

The contract (`lib.rs`) and SDK (`useInvisibleWallet.ts`) multi-passkey implementation (`Map<u32, BytesN<65>>` storage, `add_signer` / `remove_signer` methods, `__check_auth` accepting any registered key) were already in place. The 49 existing Soroban tests all pass.

## Test plan

- [x] 49 Soroban contract tests: `cargo test` in `contracts/invisible_wallet` — all pass
- [x] 215 SDK tests: `npx jest` — all pass (added 7 new tests for `addSigner`, `removeSigner`, `getSigners`)
- [ ] Manual: navigate to `/settings/passkeys` to see registered keys, click Add passkey (triggers WebAuthn registration + on-chain tx), click Remove on a second key

Closes #167