### PR TITLE
feat(a11y): screen-reader transcript for QR scanner

### DIFF
--- a/frontend/wallet/components/QrScanner.tsx
+++ b/frontend/wallet/components/QrScanner.tsx
@@ -18,10 +18,17 @@ declare const BarcodeDetector: {
   new(options: { formats: string[] }): BarcodeDetectorApi
 }
 
+export function isValidStellarAddress(addr: string): boolean {
+  return (addr.startsWith('G') || addr.startsWith('C')) && addr.length === 56
+}
+
 export function QrScanner({ onScan, onClose }: QrScannerProps) {
   const videoRef = useRef<HTMLVideoElement>(null)
   const streamRef = useRef<MediaStream | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const [announcement, setAnnouncement] = useState('')
+  const [manualAddress, setManualAddress] = useState('')
+  const [manualError, setManualError] = useState<string | null>(null)
 
   useEffect(() => {
     let animFrame = 0
@@ -59,7 +66,8 @@ export function QrScanner({ onScan, onClose }: QrScannerProps) {
             const codes = await detector.detect(video)
             for (const code of codes) {
               const addr = code.rawValue.trim()
-              if ((addr.startsWith('G') || addr.startsWith('C')) && addr.length === 56) {
+              if (isValidStellarAddress(addr)) {
+                setAnnouncement(`QR code recognized. Address: ${addr}`)
                 stop()
                 onScan(addr)
                 return
@@ -82,8 +90,22 @@ export function QrScanner({ onScan, onClose }: QrScannerProps) {
     return stop
   }, [onScan])
 
+  function handleManualSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    const addr = manualAddress.trim()
+    if (!isValidStellarAddress(addr)) {
+      setManualError('Enter a valid Stellar address (G... or C..., 56 characters).')
+      return
+    }
+    setManualError(null)
+    onScan(addr)
+  }
+
   return (
     <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Scan or enter recipient address"
       style={{
         position: 'fixed', inset: 0, zIndex: 50,
         background: 'rgba(15,15,15,0.95)',
@@ -92,6 +114,19 @@ export function QrScanner({ onScan, onClose }: QrScannerProps) {
         padding: '1.5rem',
       }}
     >
+      {/* aria-live region — announces QR recognition to screen readers */}
+      <div
+        aria-live="polite"
+        aria-atomic="true"
+        style={{
+          position: 'absolute', width: 1, height: 1,
+          overflow: 'hidden', clip: 'rect(0 0 0 0)',
+          whiteSpace: 'nowrap', border: 0,
+        }}
+      >
+        {announcement}
+      </div>
+
       <div style={{ width: '100%', maxWidth: 360 }}>
         {/* Header */}
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1rem' }}>
@@ -122,6 +157,7 @@ export function QrScanner({ onScan, onClose }: QrScannerProps) {
             ref={videoRef}
             muted
             playsInline
+            aria-label="Camera viewfinder for QR scanning"
             style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }}
           />
           {/* Corner-bracket viewfinder overlay */}
@@ -154,10 +190,77 @@ export function QrScanner({ onScan, onClose }: QrScannerProps) {
           </p>
         )}
 
+        {/* Fallback: manual address entry for screen-reader / no-camera users */}
+        <div style={{ marginTop: '1.25rem' }}>
+          <div style={{
+            display: 'flex', alignItems: 'center', gap: '0.5rem',
+            marginBottom: '0.625rem',
+          }}>
+            <div style={{ flex: 1, height: 1, background: 'rgba(246,247,248,0.15)' }} aria-hidden="true" />
+            <span style={{ fontSize: '0.6875rem', color: 'rgba(246,247,248,0.4)', whiteSpace: 'nowrap' }}>
+              or type / paste address
+            </span>
+            <div style={{ flex: 1, height: 1, background: 'rgba(246,247,248,0.15)' }} aria-hidden="true" />
+          </div>
+
+          <form onSubmit={handleManualSubmit} noValidate>
+            <label
+              htmlFor="qr-manual-address"
+              style={{
+                display: 'block', fontSize: '0.6875rem',
+                color: 'rgba(246,247,248,0.5)', marginBottom: '0.375rem',
+              }}
+            >
+              Stellar address
+            </label>
+            <input
+              id="qr-manual-address"
+              type="text"
+              value={manualAddress}
+              onChange={e => { setManualAddress(e.target.value); setManualError(null) }}
+              placeholder="G... or C..."
+              autoComplete="off"
+              spellCheck={false}
+              aria-describedby={manualError ? 'qr-manual-error' : undefined}
+              aria-invalid={manualError ? true : undefined}
+              style={{
+                width: '100%',
+                boxSizing: 'border-box',
+                background: 'rgba(246,247,248,0.06)',
+                border: `1px solid ${manualError ? 'rgba(255,80,80,0.6)' : 'rgba(246,247,248,0.15)'}`,
+                borderRadius: '0.5rem',
+                color: 'var(--off-white)',
+                fontSize: '0.8125rem',
+                padding: '0.5rem 0.75rem',
+                outline: 'none',
+              }}
+            />
+            {manualError && (
+              <p
+                id="qr-manual-error"
+                role="alert"
+                style={{
+                  marginTop: '0.375rem', fontSize: '0.75rem',
+                  color: 'rgba(255,100,100,0.9)',
+                }}
+              >
+                {manualError}
+              </p>
+            )}
+            <button
+              type="submit"
+              className="btn-ghost"
+              style={{ marginTop: '0.75rem', width: '100%' }}
+            >
+              Use this address
+            </button>
+          </form>
+        </div>
+
         <button
           className="btn-ghost"
           onClick={onClose}
-          style={{ marginTop: '1.25rem', width: '100%' }}
+          style={{ marginTop: '0.75rem', width: '100%' }}
         >
           Cancel
         </button>

--- a/frontend/wallet/components/__tests__/QrScanner.test.ts
+++ b/frontend/wallet/components/__tests__/QrScanner.test.ts
@@ -1,0 +1,31 @@
+import { isValidStellarAddress } from '../QrScanner'
+
+describe('isValidStellarAddress', () => {
+  it('accepts a valid G-address (56 chars)', () => {
+    expect(isValidStellarAddress('G' + 'A'.repeat(55))).toBe(true)
+  })
+
+  it('accepts a valid C-address (56 chars)', () => {
+    expect(isValidStellarAddress('C' + 'A'.repeat(55))).toBe(true)
+  })
+
+  it('rejects address shorter than 56 chars', () => {
+    expect(isValidStellarAddress('G' + 'A'.repeat(54))).toBe(false)
+  })
+
+  it('rejects address longer than 56 chars', () => {
+    expect(isValidStellarAddress('G' + 'A'.repeat(56))).toBe(false)
+  })
+
+  it('rejects address with wrong prefix', () => {
+    expect(isValidStellarAddress('X' + 'A'.repeat(55))).toBe(false)
+  })
+
+  it('rejects empty string', () => {
+    expect(isValidStellarAddress('')).toBe(false)
+  })
+
+  it('rejects address with leading whitespace (untrimmed)', () => {
+    expect(isValidStellarAddress(' G' + 'A'.repeat(54))).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

- Add a labeled "type / paste address" fallback form directly below the QR viewfinder, always visible and usable without camera access
- Announce QR code recognition to screen readers via an `aria-live="polite"` visually-hidden region
- Add `role="dialog"`, `aria-modal="true"`, and `aria-label` to the scanner overlay
- Add `aria-label` to the `<video>` element
- Extract `isValidStellarAddress` as an exported pure helper (same logic as before)

## Changes

- `frontend/wallet/components/QrScanner.tsx` — aria-live region, manual-entry form with label/error/submit, dialog role, video aria-label, exported validation helper
- `frontend/wallet/components/__tests__/QrScanner.test.ts` — 7 unit tests for `isValidStellarAddress`

## Verification

- Fallback input renders below the viewfinder on every open; submitting a valid 56-char G/C address calls `onScan` immediately
- Submitting an invalid address shows an `role="alert"` error message
- When a QR code is detected, the `aria-live` region is updated with `"QR code recognized. Address: <addr>"` before `onScan` fires
- Unit tests: 7/7 pass

closes #373