### PR TITLE
feat(wallet): Sentry error reporting with opt-in toggle

### DIFF
--- a/frontend/wallet/app/SentryInit.tsx
+++ b/frontend/wallet/app/SentryInit.tsx
@@ -1,0 +1,11 @@
+'use client'
+
+import { useEffect } from 'react'
+import { initSentry } from '@/lib/sentry'
+
+export function SentryInit() {
+  useEffect(() => {
+    initSentry()
+  }, [])
+  return null
+}

--- a/frontend/wallet/app/layout.tsx
+++ b/frontend/wallet/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from 'next'
 import './globals.css'
 import { InstallBanner } from './InstallBanner'
+import { SentryInit } from './SentryInit'
 
 export const metadata: Metadata = {
   title: 'Veil Wallet',
@@ -35,6 +36,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <body>
         {children}
         <InstallBanner />
+        <SentryInit />
       </body>
     </html>
   )

--- a/frontend/wallet/app/settings/page.tsx
+++ b/frontend/wallet/app/settings/page.tsx
@@ -494,6 +494,25 @@ export default function SettingsPage() {
                 </div>
               </button>
 
+              {/* Privacy */}
+              <button
+                className="card"
+                onClick={() => router.push('/settings/privacy')}
+                style={{ textAlign: 'left', cursor: 'pointer', width: '100%', border: '1px solid var(--border-dim)', background: 'var(--surface)' }}
+              >
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                  <div>
+                    <p style={{ fontWeight: 500, fontSize: '0.9375rem' }}>Privacy</p>
+                    <p style={{ fontSize: '0.8125rem', color: 'rgba(246,247,248,0.4)', marginTop: '0.25rem' }}>
+                      Error reporting and data preferences
+                    </p>
+                  </div>
+                  <svg width="16" height="16" viewBox="0 0 16 16" fill="none" style={{ flexShrink: 0 }}>
+                    <path d="M6 3l5 5-5 5" stroke="rgba(246,247,248,0.3)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+                  </svg>
+                </div>
+              </button>
+
               {/* Address Book card */}
               <button
                 className="card"

--- a/frontend/wallet/app/settings/privacy/page.tsx
+++ b/frontend/wallet/app/settings/privacy/page.tsx
@@ -1,0 +1,109 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { ChevronLeft, ShieldCheck } from 'lucide-react'
+import { getSentryOptIn, setSentryOptIn, initSentry } from '@/lib/sentry'
+
+export default function PrivacySettingsPage() {
+  const router = useRouter()
+  const [optIn, setOptIn] = useState(false)
+
+  useEffect(() => {
+    setOptIn(getSentryOptIn())
+  }, [])
+
+  function toggle() {
+    const next = !optIn
+    setSentryOptIn(next)
+    setOptIn(next)
+    if (next) initSentry()
+  }
+
+  return (
+    <div className="wallet-shell" style={{ padding: '1.5rem 1.25rem 4rem' }}>
+      <div style={{ maxWidth: 480, width: '100%', margin: '0 auto' }}>
+        {/* Header */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', marginBottom: '1.75rem' }}>
+          <button
+            type="button"
+            onClick={() => router.push('/settings')}
+            aria-label="Back to settings"
+            style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--off-white)', display: 'flex', padding: 0 }}
+          >
+            <ChevronLeft size={22} strokeWidth={1.75} />
+          </button>
+          <h1 style={{ fontFamily: 'Lora, Georgia, serif', fontWeight: 600, fontStyle: 'italic', fontSize: '1.375rem', color: 'var(--off-white)' }}>
+            Privacy
+          </h1>
+        </div>
+
+        {/* Error reporting section */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.625rem', marginBottom: '0.5rem' }}>
+          <ShieldCheck size={16} color="var(--gold)" strokeWidth={1.75} />
+          <p style={{ fontFamily: 'Anton, Impact, sans-serif', letterSpacing: '0.06em', fontSize: '0.75rem', color: 'rgba(246,247,248,0.5)' }}>
+            ERROR REPORTING
+          </p>
+        </div>
+        <p style={{ fontSize: '0.8125rem', color: 'rgba(246,247,248,0.4)', lineHeight: 1.6, marginBottom: '1rem' }}>
+          Help improve Veil by sending anonymous crash reports. No addresses, amounts, or
+          personal data are ever included. Disabled by default.
+        </p>
+
+        <button
+          type="button"
+          onClick={toggle}
+          className="card"
+          aria-pressed={optIn}
+          style={{
+            textAlign: 'left',
+            cursor: 'pointer',
+            width: '100%',
+            border: `1px solid ${optIn ? 'var(--gold)' : 'var(--border-dim)'}`,
+            background: 'var(--surface)',
+          }}
+        >
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <div>
+              <p style={{ fontWeight: 500, fontSize: '0.9375rem' }}>Send crash reports</p>
+              <p style={{ fontSize: '0.8125rem', color: 'rgba(246,247,248,0.4)', marginTop: '0.25rem' }}>
+                {optIn ? 'Enabled — thank you for helping improve Veil' : 'Disabled'}
+              </p>
+            </div>
+            {/* Toggle pill */}
+            <div
+              aria-hidden="true"
+              style={{
+                width: 44,
+                height: 24,
+                borderRadius: 12,
+                background: optIn ? 'var(--gold)' : 'rgba(246,247,248,0.15)',
+                position: 'relative',
+                flexShrink: 0,
+                transition: 'background 0.2s',
+              }}
+            >
+              <div
+                style={{
+                  position: 'absolute',
+                  top: 3,
+                  left: optIn ? 23 : 3,
+                  width: 18,
+                  height: 18,
+                  borderRadius: '50%',
+                  background: 'var(--off-white)',
+                  transition: 'left 0.2s',
+                }}
+              />
+            </div>
+          </div>
+        </button>
+
+        <p style={{ fontSize: '0.75rem', color: 'rgba(246,247,248,0.25)', marginTop: '0.75rem', lineHeight: 1.6 }}>
+          Reports are sent to Sentry and contain only stack traces with wallet addresses and
+          amounts stripped out. You can opt out at any time.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/frontend/wallet/lib/__tests__/sentry.test.ts
+++ b/frontend/wallet/lib/__tests__/sentry.test.ts
@@ -1,0 +1,110 @@
+jest.mock('@sentry/nextjs', () => ({ init: jest.fn() }), { virtual: true })
+
+import * as SentryMock from '@sentry/nextjs'
+import {
+  getSentryOptIn,
+  setSentryOptIn,
+  scrubEvent,
+  initSentry,
+  resetSentryInitForTesting,
+} from '../sentry'
+
+beforeEach(() => {
+  localStorage.clear()
+  jest.clearAllMocks()
+  resetSentryInitForTesting()
+})
+
+describe('getSentryOptIn / setSentryOptIn', () => {
+  it('defaults to false', () => {
+    expect(getSentryOptIn()).toBe(false)
+  })
+
+  it('round-trips true', () => {
+    setSentryOptIn(true)
+    expect(getSentryOptIn()).toBe(true)
+  })
+
+  it('round-trips false after true', () => {
+    setSentryOptIn(true)
+    setSentryOptIn(false)
+    expect(getSentryOptIn()).toBe(false)
+  })
+
+  it('returns false for arbitrary stored value', () => {
+    localStorage.setItem('veil_sentry_opt_in', 'yes')
+    expect(getSentryOptIn()).toBe(false)
+  })
+})
+
+describe('scrubEvent', () => {
+  function makeEvent(message: string) {
+    return { message, exception: undefined }
+  }
+
+  it('scrubs Stellar public address from message', () => {
+    const addr = 'G' + 'A'.repeat(55)
+    const event = makeEvent(`sent 5 XLM to ${addr}`)
+    const result = scrubEvent(event as any)
+    expect(result?.message).not.toContain(addr)
+    expect(result?.message).toContain('[address]')
+  })
+
+  it('scrubs Stellar secret key from message', () => {
+    const secret = 'S' + 'A'.repeat(55)
+    const event = makeEvent(`key=${secret}`)
+    const result = scrubEvent(event as any)
+    expect(result?.message).not.toContain(secret)
+    expect(result?.message).toContain('[secret]')
+  })
+
+  it('scrubs amounts with asset suffix from message', () => {
+    const event = makeEvent('transferred 12.5 XLM to friend')
+    const result = scrubEvent(event as any)
+    expect(result?.message).not.toMatch(/12\.5 XLM/)
+    expect(result?.message).toContain('[amount]')
+  })
+
+  it('scrubs exception value', () => {
+    const addr = 'G' + 'B'.repeat(55)
+    const event = {
+      message: undefined,
+      exception: { values: [{ value: `Error sending to ${addr}` }] },
+    }
+    const result = scrubEvent(event as any)
+    expect(result?.exception?.values?.[0]?.value).not.toContain(addr)
+    expect(result?.exception?.values?.[0]?.value).toContain('[address]')
+  })
+
+  it('returns the event unchanged when no PII present', () => {
+    const event = makeEvent('TypeError: Cannot read properties of undefined')
+    const result = scrubEvent(event as any)
+    expect(result?.message).toBe('TypeError: Cannot read properties of undefined')
+  })
+})
+
+describe('initSentry', () => {
+  it('does not call Sentry.init when opt-in is off (default)', () => {
+    initSentry()
+    expect(SentryMock.init).not.toHaveBeenCalled()
+  })
+
+  it('calls Sentry.init when opted in', () => {
+    setSentryOptIn(true)
+    initSentry()
+    expect(SentryMock.init).toHaveBeenCalledTimes(1)
+    const cfg = (SentryMock.init as jest.Mock).mock.calls[0][0]
+    expect(cfg).toMatchObject({
+      tracesSampleRate: 0,
+      environment: expect.any(String),
+    })
+    expect(typeof cfg.beforeSend).toBe('function')
+  })
+
+  it('is idempotent — second call does not re-init', () => {
+    setSentryOptIn(true)
+    initSentry()
+    initSentry()
+    expect(SentryMock.init).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/wallet/lib/sentry.ts
+++ b/frontend/wallet/lib/sentry.ts
@@ -1,0 +1,60 @@
+import * as Sentry from '@sentry/nextjs'
+
+const STORAGE_KEY = 'veil_sentry_opt_in'
+
+// Stellar public key: G + 55 base32 chars; secret key: S + 55 base32 chars
+const STELLAR_ADDRESS_RE = /\bG[A-Z2-7]{55}\b/g
+const STELLAR_SECRET_RE = /\bS[A-Z2-7]{55}\b/g
+// Amounts with or without a known asset suffix
+const AMOUNT_RE = /\b\d+(\.\d+)?(\s*(XLM|USDC|BTC|ETH|xlm|usdc|btc|eth))?\b(?=\s*(?:XLM|USDC|BTC|ETH|xlm|usdc|btc|eth))/g
+
+export function getSentryOptIn(): boolean {
+  if (typeof window === 'undefined') return false
+  return window.localStorage.getItem(STORAGE_KEY) === 'true'
+}
+
+export function setSentryOptIn(value: boolean): void {
+  if (typeof window === 'undefined') return
+  window.localStorage.setItem(STORAGE_KEY, String(value))
+}
+
+type SentryEvent = Parameters<NonNullable<Parameters<typeof Sentry.init>[0]['beforeSend']>>[0]
+
+function scrubString(s: string): string {
+  return s
+    .replace(STELLAR_SECRET_RE, '[secret]')
+    .replace(STELLAR_ADDRESS_RE, '[address]')
+    .replace(/\b\d+(\.\d+)?\s+(XLM|USDC|BTC|ETH|xlm|usdc|btc|eth)\b/g, '[amount]')
+}
+
+export function scrubEvent(event: SentryEvent): SentryEvent | null {
+  if (event.message) {
+    event.message = scrubString(event.message)
+  }
+  if (event.exception?.values) {
+    for (const ex of event.exception.values) {
+      if (ex.value) ex.value = scrubString(ex.value)
+    }
+  }
+  return event
+}
+
+let initialized = false
+
+export function initSentry(): void {
+  if (typeof window === 'undefined') return
+  if (!getSentryOptIn()) return
+  if (initialized) return
+  initialized = true
+
+  Sentry.init({
+    dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+    environment: process.env.NODE_ENV,
+    tracesSampleRate: 0,
+    beforeSend: scrubEvent,
+  })
+}
+
+export function resetSentryInitForTesting(): void {
+  initialized = false
+}

--- a/frontend/wallet/package.json
+++ b/frontend/wallet/package.json
@@ -14,6 +14,7 @@
     "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
+    "@sentry/nextjs": "^8.0.0",
     "@blend-capital/blend-sdk": "^3.2.2",
     "@soroswap/sdk": "^0.4.0",
     "@stellar/stellar-sdk": "^14.6.1",


### PR DESCRIPTION
## Summary

- Adds `@sentry/nextjs` to the wallet PWA, initialized lazily only when the user has opted in
- New `lib/sentry.ts`: `getSentryOptIn`/`setSentryOptIn` (localStorage), `scrubEvent` PII hook, `initSentry` (idempotent, no-op when opted out)
- New Settings → Privacy page (`app/settings/privacy/page.tsx`) with a toggle that persists and calls `initSentry()` immediately on enable
- Privacy card added to the Settings overview between Security & Lock and Address Book
- `SentryInit` client component in root layout re-runs `initSentry()` on every page load (no-op unless opted in)
- `tracesSampleRate: 0` — performance tracing off; only error events sent
- `beforeSend` scrubber strips Stellar public keys (G…56 chars), secret keys (S…56 chars), and amounts with asset suffixes before any event leaves the device

## Verification

12 unit tests in `lib/__tests__/sentry.test.ts`:
- opt-in defaults to `false`, round-trips correctly
- `scrubEvent` removes addresses, secrets, and amounts from message and exception values
- `initSentry` no-ops when opted out, calls `Sentry.init` exactly once when opted in (idempotent)

All 12 pass. `@sentry/nextjs` mocked with `{ virtual: true }` so tests run without installing the package in CI (real install via `package.json` entry).

closes #372