### PR TITLE
feat(wallet): passkey signer rotation without wallet redeployment

### DIFF
--- a/contracts/invisible_wallet/src/lib.rs
+++ b/contracts/invisible_wallet/src/lib.rs
@@ -56,6 +56,8 @@ pub enum WalletError {
     SessionKeyExpired           = 19,
     /// A session key call violates its ACL (wrong target, selector, or cumulative budget exceeded).
     SessionKeyAclViolation      = 20,
+    /// The replacement key passed to `rotate_signer` is already a registered signer.
+    SignerAlreadyExists         = 21,
 }
 
 #[contract]
@@ -107,6 +109,46 @@ impl InvisibleWallet {
         }
 
         if !storage::remove_signer(&env, index) {
+            return Err(WalletError::SignerNotFound);
+        }
+
+        Ok(())
+    }
+
+    /// Atomically replace a registered signer key (`old_public_key`) with a new
+    /// one (`new_public_key`) — the device-rotation flow for a lost or replaced
+    /// passkey.
+    ///
+    /// Requires authorization from the contract itself, so an *existing* signer
+    /// must authorize the call via `__check_auth`. This means only the current
+    /// owner can rotate the key: a lost device cannot be silently swapped out by
+    /// a third party.
+    ///
+    /// The new key takes over the **same index** as the old one, so the signer
+    /// set size is unchanged and — critically — the wallet's contract address and
+    /// balances are untouched. No redeploy is needed.
+    ///
+    /// Errors:
+    /// * `InvalidPublicKey`     — `old` and `new` are the same key (no-op).
+    /// * `SignerAlreadyExists`  — `new_public_key` is already registered.
+    /// * `SignerNotFound`       — `old_public_key` is not a registered signer.
+    pub fn rotate_signer(
+        env: Env,
+        old_public_key: BytesN<65>,
+        new_public_key: BytesN<65>,
+    ) -> Result<(), WalletError> {
+        env.current_contract_address().require_auth();
+
+        if old_public_key == new_public_key {
+            return Err(WalletError::InvalidPublicKey);
+        }
+
+        // Reject collapsing two slots into a duplicate key.
+        if storage::has_signer(&env, &new_public_key) {
+            return Err(WalletError::SignerAlreadyExists);
+        }
+
+        if !storage::replace_signer(&env, &old_public_key, &new_public_key) {
             return Err(WalletError::SignerNotFound);
         }
 
@@ -771,6 +813,166 @@ mod test {
             client.try_remove_signer(&99),
             Err(Ok(WalletError::SignerNotFound))
         );
+    }
+
+    // ── Rotate-signer tests ───────────────────────────────────────────────────
+
+    fn third_keypair() -> (SigningKey, [u8; 65]) {
+        let signing_key = SigningKey::from_bytes(&[7u8; 32].into()).unwrap();
+        let encoded = signing_key.verifying_key().to_encoded_point(false);
+        let pub_bytes: [u8; 65] = encoded.as_bytes().try_into().unwrap();
+        (signing_key, pub_bytes)
+    }
+
+    #[test]
+    fn test_rotate_signer_swaps_key_and_keeps_address() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, InvisibleWallet);
+        let client = InvisibleWalletClient::new(&env, &contract_id);
+
+        let (_, old_pub) = test_keypair();
+        let (_, new_pub) = third_keypair();
+        let rp_id  = bytes_from_str(&env, "localhost");
+        let origin = bytes_from_str(&env, "https://localhost:5173");
+
+        let old_key = BytesN::from_array(&env, &old_pub);
+        let new_key = BytesN::from_array(&env, &new_pub);
+
+        client.init(&old_key, &rp_id, &origin);
+        let count_before = client.get_signers().len();
+
+        client.rotate_signer(&old_key, &new_key);
+
+        // New key authorizes, old key rejected.
+        assert!(client.has_signer(&new_key));
+        assert!(!client.has_signer(&old_key));
+        // Signer set size unchanged — the new key took the old key's slot.
+        assert_eq!(client.get_signers().len(), count_before);
+        // Wallet address (contract id) is untouched by the rotation.
+        assert_eq!(client.address, contract_id);
+    }
+
+    #[test]
+    fn test_rotate_signer_preserves_other_signers() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, InvisibleWallet);
+        let client = InvisibleWalletClient::new(&env, &contract_id);
+
+        let (_, first_pub)  = test_keypair();
+        let (_, second_pub) = second_keypair();
+        let (_, new_pub)    = third_keypair();
+        let rp_id  = bytes_from_str(&env, "localhost");
+        let origin = bytes_from_str(&env, "https://localhost:5173");
+
+        let first_key  = BytesN::from_array(&env, &first_pub);
+        let second_key = BytesN::from_array(&env, &second_pub);
+        let new_key    = BytesN::from_array(&env, &new_pub);
+
+        client.init(&first_key, &rp_id, &origin);
+        client.add_signer(&second_key);
+
+        // Rotate only the first signer; the second must remain untouched.
+        client.rotate_signer(&first_key, &new_key);
+
+        assert!(client.has_signer(&new_key));
+        assert!(!client.has_signer(&first_key));
+        assert!(client.has_signer(&second_key));
+        assert_eq!(client.get_signers().len(), 2);
+    }
+
+    #[test]
+    fn test_rotate_signer_unknown_old_key_fails() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, InvisibleWallet);
+        let client = InvisibleWalletClient::new(&env, &contract_id);
+
+        let (_, old_pub) = test_keypair();
+        let (_, other_pub) = second_keypair();
+        let (_, new_pub) = third_keypair();
+        let rp_id  = bytes_from_str(&env, "localhost");
+        let origin = bytes_from_str(&env, "https://localhost:5173");
+
+        client.init(&BytesN::from_array(&env, &old_pub), &rp_id, &origin);
+
+        assert_eq!(
+            client.try_rotate_signer(
+                &BytesN::from_array(&env, &other_pub),
+                &BytesN::from_array(&env, &new_pub),
+            ),
+            Err(Ok(WalletError::SignerNotFound))
+        );
+    }
+
+    #[test]
+    fn test_rotate_signer_to_existing_key_fails() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, InvisibleWallet);
+        let client = InvisibleWalletClient::new(&env, &contract_id);
+
+        let (_, first_pub)  = test_keypair();
+        let (_, second_pub) = second_keypair();
+        let rp_id  = bytes_from_str(&env, "localhost");
+        let origin = bytes_from_str(&env, "https://localhost:5173");
+
+        let first_key  = BytesN::from_array(&env, &first_pub);
+        let second_key = BytesN::from_array(&env, &second_pub);
+
+        client.init(&first_key, &rp_id, &origin);
+        client.add_signer(&second_key);
+
+        // Rotating onto an already-registered key would create a duplicate.
+        assert_eq!(
+            client.try_rotate_signer(&first_key, &second_key),
+            Err(Ok(WalletError::SignerAlreadyExists))
+        );
+    }
+
+    #[test]
+    fn test_rotate_signer_same_key_fails() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, InvisibleWallet);
+        let client = InvisibleWalletClient::new(&env, &contract_id);
+
+        let (_, pub_bytes) = test_keypair();
+        let rp_id  = bytes_from_str(&env, "localhost");
+        let origin = bytes_from_str(&env, "https://localhost:5173");
+
+        let key = BytesN::from_array(&env, &pub_bytes);
+        client.init(&key, &rp_id, &origin);
+
+        assert_eq!(
+            client.try_rotate_signer(&key, &key),
+            Err(Ok(WalletError::InvalidPublicKey))
+        );
+    }
+
+    /// Rotation must be authorized by the current signer. Without any auth mocked,
+    /// `current_contract_address().require_auth()` rejects the call.
+    #[test]
+    #[should_panic]
+    fn test_rotate_signer_requires_current_signer_auth() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, InvisibleWallet);
+        let client = InvisibleWalletClient::new(&env, &contract_id);
+
+        let (_, old_pub) = test_keypair();
+        let (_, new_pub) = third_keypair();
+        let rp_id  = bytes_from_str(&env, "localhost");
+        let origin = bytes_from_str(&env, "https://localhost:5173");
+
+        let old_key = BytesN::from_array(&env, &old_pub);
+        let new_key = BytesN::from_array(&env, &new_pub);
+
+        // init does not require auth; the rotation below does.
+        client.init(&old_key, &rp_id, &origin);
+
+        // No env.mock_all_auths() → require_auth() panics with "Unauthorized".
+        client.rotate_signer(&old_key, &new_key);
     }
 
     // ── WebAuthn verification tests ───────────────────────────────────────────

--- a/contracts/invisible_wallet/src/storage.rs
+++ b/contracts/invisible_wallet/src/storage.rs
@@ -74,6 +74,22 @@ pub fn remove_signer(env: &Env, index: u32) -> bool {
     }
 }
 
+/// Replace the public key of an existing signer in place, keeping the same
+/// index so the signer set size and slot layout are preserved. Returns true if
+/// `old_key` was found and replaced, false otherwise. Used by `rotate_signer`
+/// to swap a lost device's key without re-deploying the wallet.
+pub fn replace_signer(env: &Env, old_key: &BytesN<65>, new_key: &BytesN<65>) -> bool {
+    let mut signers = get_signers(env);
+    for (index, stored_key) in signers.iter() {
+        if stored_key == *old_key {
+            signers.set(index, new_key.clone());
+            env.storage().instance().set(&DataKey::Signers, &signers);
+            return true;
+        }
+    }
+    false
+}
+
 /// Check if any signer key matches the given public key.
 pub fn has_signer(env: &Env, key: &BytesN<65>) -> bool {
     let signers = get_signers(env);

--- a/contracts/invisible_wallet/test_snapshots/test/test_rotate_signer_preserves_other_signers.1.json
+++ b/contracts/invisible_wallet/test_snapshots/test/test_rotate_signer_preserves_other_signers.1.json
@@ -1,0 +1,253 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "add_signer",
+              "args": [
+                {
+                  "bytes": "042ed2192f0f9275200acd34fbd8c6ce5a91a459488411320b4c6de3e6a22d7fa06f2374f60534a9009629714d063402a3c3ed60db057ef7999a7a31a78aebc0c7"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "rotate_signer",
+              "args": [
+                {
+                  "bytes": "040c901d423c831ca85e27c73c263ba132721bb9d7a84c4f0380b2a6756fd601331c8870234dec878504c174144fa4b14b66a651691606d8173e55bd37e381569e"
+                },
+                {
+                  "bytes": "041e18532fd4754c02f3041d9c75ceb33b83ffd81ac7ce4fe882ccb1c98bc5896ea46c311c4e2ff40dd96a3653e6e45445d32dfe486eced75c7a90c6a18881c0a3"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Nonce"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 0
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Origin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bytes": "68747470733a2f2f6c6f63616c686f73743a35313733"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "RpId"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bytes": "6c6f63616c686f7374"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Signers"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "u32": 0
+                              },
+                              "val": {
+                                "bytes": "041e18532fd4754c02f3041d9c75ceb33b83ffd81ac7ce4fe882ccb1c98bc5896ea46c311c4e2ff40dd96a3653e6e45445d32dfe486eced75c7a90c6a18881c0a3"
+                              }
+                            },
+                            {
+                              "key": {
+                                "u32": 1
+                              },
+                              "val": {
+                                "bytes": "042ed2192f0f9275200acd34fbd8c6ce5a91a459488411320b4c6de3e6a22d7fa06f2374f60534a9009629714d063402a3c3ed60db057ef7999a7a31a78aebc0c7"
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/invisible_wallet/test_snapshots/test/test_rotate_signer_requires_current_signer_auth.1.json
+++ b/contracts/invisible_wallet/test_snapshots/test/test_rotate_signer_requires_current_signer_auth.1.json
@@ -1,0 +1,135 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Nonce"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 0
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Origin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bytes": "68747470733a2f2f6c6f63616c686f73743a35313733"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "RpId"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bytes": "6c6f63616c686f7374"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Signers"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "u32": 0
+                              },
+                              "val": {
+                                "bytes": "040c901d423c831ca85e27c73c263ba132721bb9d7a84c4f0380b2a6756fd601331c8870234dec878504c174144fa4b14b66a651691606d8173e55bd37e381569e"
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/invisible_wallet/test_snapshots/test/test_rotate_signer_same_key_fails.1.json
+++ b/contracts/invisible_wallet/test_snapshots/test/test_rotate_signer_same_key_fails.1.json
@@ -1,0 +1,135 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Nonce"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 0
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Origin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bytes": "68747470733a2f2f6c6f63616c686f73743a35313733"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "RpId"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bytes": "6c6f63616c686f7374"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Signers"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "u32": 0
+                              },
+                              "val": {
+                                "bytes": "040c901d423c831ca85e27c73c263ba132721bb9d7a84c4f0380b2a6756fd601331c8870234dec878504c174144fa4b14b66a651691606d8173e55bd37e381569e"
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/invisible_wallet/test_snapshots/test/test_rotate_signer_swaps_key_and_keeps_address.1.json
+++ b/contracts/invisible_wallet/test_snapshots/test/test_rotate_signer_swaps_key_and_keeps_address.1.json
@@ -1,0 +1,193 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "rotate_signer",
+              "args": [
+                {
+                  "bytes": "040c901d423c831ca85e27c73c263ba132721bb9d7a84c4f0380b2a6756fd601331c8870234dec878504c174144fa4b14b66a651691606d8173e55bd37e381569e"
+                },
+                {
+                  "bytes": "041e18532fd4754c02f3041d9c75ceb33b83ffd81ac7ce4fe882ccb1c98bc5896ea46c311c4e2ff40dd96a3653e6e45445d32dfe486eced75c7a90c6a18881c0a3"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Nonce"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 0
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Origin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bytes": "68747470733a2f2f6c6f63616c686f73743a35313733"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "RpId"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bytes": "6c6f63616c686f7374"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Signers"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "u32": 0
+                              },
+                              "val": {
+                                "bytes": "041e18532fd4754c02f3041d9c75ceb33b83ffd81ac7ce4fe882ccb1c98bc5896ea46c311c4e2ff40dd96a3653e6e45445d32dfe486eced75c7a90c6a18881c0a3"
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/invisible_wallet/test_snapshots/test/test_rotate_signer_to_existing_key_fails.1.json
+++ b/contracts/invisible_wallet/test_snapshots/test/test_rotate_signer_to_existing_key_fails.1.json
@@ -1,0 +1,195 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "add_signer",
+              "args": [
+                {
+                  "bytes": "042ed2192f0f9275200acd34fbd8c6ce5a91a459488411320b4c6de3e6a22d7fa06f2374f60534a9009629714d063402a3c3ed60db057ef7999a7a31a78aebc0c7"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Nonce"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 0
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Origin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bytes": "68747470733a2f2f6c6f63616c686f73743a35313733"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "RpId"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bytes": "6c6f63616c686f7374"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Signers"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "u32": 0
+                              },
+                              "val": {
+                                "bytes": "040c901d423c831ca85e27c73c263ba132721bb9d7a84c4f0380b2a6756fd601331c8870234dec878504c174144fa4b14b66a651691606d8173e55bd37e381569e"
+                              }
+                            },
+                            {
+                              "key": {
+                                "u32": 1
+                              },
+                              "val": {
+                                "bytes": "042ed2192f0f9275200acd34fbd8c6ce5a91a459488411320b4c6de3e6a22d7fa06f2374f60534a9009629714d063402a3c3ed60db057ef7999a7a31a78aebc0c7"
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/invisible_wallet/test_snapshots/test/test_rotate_signer_unknown_old_key_fails.1.json
+++ b/contracts/invisible_wallet/test_snapshots/test/test_rotate_signer_unknown_old_key_fails.1.json
@@ -1,0 +1,135 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Nonce"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 0
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Origin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bytes": "68747470733a2f2f6c6f63616c686f73743a35313733"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "RpId"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bytes": "6c6f63616c686f7374"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Signers"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "u32": 0
+                              },
+                              "val": {
+                                "bytes": "040c901d423c831ca85e27c73c263ba132721bb9d7a84c4f0380b2a6756fd601331c8870234dec878504c174144fa4b14b66a651691606d8173e55bd37e381569e"
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/sdk/src/__tests__/useInvisibleWallet.test.ts
+++ b/sdk/src/__tests__/useInvisibleWallet.test.ts
@@ -8,7 +8,7 @@
 
 import { renderHook, act } from '@testing-library/react'
 import { useInvisibleWallet } from '../useInvisibleWallet'
-import { rpc as SorobanRpc, TransactionBuilder } from '@stellar/stellar-sdk'
+import { rpc as SorobanRpc, TransactionBuilder, Keypair } from '@stellar/stellar-sdk'
 
 // ── @stellar/stellar-sdk mock ─────────────────────────────────────────────────
 
@@ -385,6 +385,75 @@ describe('useInvisibleWallet', () => {
       await expect(
         act(async () => { await result.current.signAuthEntry(payload) })
       ).rejects.toThrow(/No key ID/)
+    })
+  })
+
+  // ── rotateSigner() ───────────────────────────────────────────────────────────
+
+  describe('rotateSigner()', () => {
+    beforeEach(() => {
+      localStorage.setItem('invisible_wallet_address', 'CEXISTING_WALLET')
+      localStorage.setItem('invisible_wallet_public_key', 'aabbcc')
+      localStorage.setItem('invisible_wallet_key_id', 'bW9jay1jcmVkZW50aWFsLWlk')
+
+      // The default Server mock lacks getAccount, which rotateSigner needs.
+      jest.mocked(SorobanRpc.Server).mockImplementation(
+        () =>
+          ({
+            getAccount: jest.fn().mockResolvedValue({
+              accountId:      () => 'GPUBKEY',
+              sequenceNumber: () => '0',
+            }),
+            getContractData:     jest.fn().mockResolvedValue({}),
+            simulateTransaction: jest.fn().mockResolvedValue({
+              result: { retval: {} },
+              minResourceFee: '0',
+              transactionData: {},
+              events: [],
+              latestLedger: 1,
+            }),
+            sendTransaction: jest.fn().mockResolvedValue({ status: 'PENDING', hash: 'mock-hash' }),
+            getTransaction:  jest.fn().mockResolvedValue({ status: 'SUCCESS' }),
+          }) as any,
+      )
+    })
+
+    it('registers a new credential, preserves the wallet address, and stores the new key', async () => {
+      mockCredentialsCreate.mockResolvedValueOnce(makeMockRegistrationCredential())
+
+      const { result } = renderHook(() => useInvisibleWallet(CONFIG))
+      await act(async () => {}) // flush mount effect so the stored address is picked up
+
+      const keypair = Keypair.fromSecret('SUSER')
+
+      let rotateResult!: Awaited<ReturnType<typeof result.current.rotateSigner>>
+      await act(async () => {
+        rotateResult = await result.current.rotateSigner(keypair as any, 'new-device')
+      })
+
+      // A brand-new WebAuthn credential was registered.
+      expect(mockCredentialsCreate).toHaveBeenCalledTimes(1)
+      // The wallet address (and therefore balances) is unchanged.
+      expect(rotateResult.walletAddress).toBe('CEXISTING_WALLET')
+      expect(result.current.address).toBe('CEXISTING_WALLET')
+      // A new 65-byte uncompressed P-256 key was produced.
+      expect(rotateResult.newPublicKeyBytes).toHaveLength(65)
+      // Storage now holds the new public key, not the old one.
+      expect(localStorage.getItem('invisible_wallet_public_key')).not.toBe('aabbcc')
+      expect(result.current.error).toBeNull()
+    })
+
+    it('throws when there is no existing public key in storage', async () => {
+      localStorage.removeItem('invisible_wallet_public_key')
+      mockCredentialsCreate.mockResolvedValueOnce(makeMockRegistrationCredential())
+
+      const { result } = renderHook(() => useInvisibleWallet(CONFIG))
+      await act(async () => {})
+
+      const keypair = Keypair.fromSecret('SUSER')
+      await expect(
+        act(async () => { await result.current.rotateSigner(keypair as any) })
+      ).rejects.toThrow(/No existing public key/)
     })
   })
 

--- a/sdk/src/useInvisibleWallet.ts
+++ b/sdk/src/useInvisibleWallet.ts
@@ -184,6 +184,19 @@ export type AddSignerResult = {
     signerIndex: number;
 };
 
+/** Result returned by a successful rotateSigner() call. */
+export type RotateSignerResult = {
+    /** The previous (rotated-out) P-256 public key bytes (65 bytes). */
+    oldPublicKeyBytes: Uint8Array;
+    /** The newly registered P-256 public key bytes (65 bytes). */
+    newPublicKeyBytes: Uint8Array;
+    /**
+     * The wallet's contract address — unchanged by the rotation. Returned so
+     * callers can assert that the address (and therefore balances) is preserved.
+     */
+    walletAddress: string;
+};
+
 /** Result returned by getSigners(). */
 export type SignerInfo = {
     /** The index of the signer in the wallet's signer list. */
@@ -299,6 +312,25 @@ export type InvisibleWallet = {
      * @param signerIndex   The index of the signer to remove.
      */
     removeSigner: (signerKeypair: Keypair, signerIndex: number) => Promise<void>;
+    /**
+     * Rotate the wallet's passkey signer without redeploying — the device-loss
+     * recovery flow. Registers a brand-new WebAuthn credential, then calls the
+     * contract's `rotate_signer(old_key, new_key)` entrypoint, authorizing the
+     * swap with the **current** passkey (an interactive assertion). The wallet
+     * address and balances are preserved; afterwards the new credential becomes
+     * the active signer in storage.
+     *
+     * Two user gestures are involved: creating the new credential, and signing
+     * the rotation with the existing one.
+     *
+     * @param signerKeypair Stellar Keypair used as the transaction fee source.
+     *                      Separate from the passkey — pays fees only.
+     * @param username      Optional display name for the new credential.
+     * @param options       Optional WebAuthn options for the new credential
+     *                      (e.g. `authenticatorAttachment`).
+     * @returns The old/new public keys and the unchanged wallet address.
+     */
+    rotateSigner: (signerKeypair: Keypair, username?: string, options?: RegisterOptions) => Promise<RotateSignerResult>;
     /**
      * Fetch the list of all registered signers from the wallet contract.
      *
@@ -1162,6 +1194,191 @@ export function useInvisibleWallet(config: WalletConfig): InvisibleWallet {
         }
     }, [address, rpcUrl, networkPassphrase, signAuthEntry, config]);
 
+    // ── rotateSigner ──────────────────────────────────────────────────────────
+
+    const rotateSigner = useCallback(async (
+        signerKeypair: Keypair,
+        username?: string,
+        options?: RegisterOptions
+    ): Promise<RotateSignerResult> => {
+        setIsPending(true);
+        setError(null);
+        try {
+            if (!address) throw new Error('No wallet address. Call register() or login() first.');
+
+            // The key currently registered on-chain — read before we touch storage.
+            const oldPublicKeyHex = await store.getItem('invisible_wallet_public_key');
+            if (!oldPublicKeyHex) {
+                throw new Error('No existing public key found. Call register() or login() first.');
+            }
+            const oldPublicKeyBytes = hexToUint8Array(oldPublicKeyHex);
+
+            // 1. Register a brand-new WebAuthn credential for the new device.
+            const challenge = crypto.getRandomValues(new Uint8Array(32));
+            const normalizedUsername = username ? username.normalize('NFC') : undefined;
+            const name   = normalizedUsername || 'Veil User';
+            const userId = normalizedUsername
+                ? new TextEncoder().encode(normalizedUsername)
+                : crypto.getRandomValues(new Uint8Array(16));
+            const resolvedRpId = rpId ?? (typeof window !== 'undefined' ? window.location.hostname : 'localhost');
+
+            const {
+                credentialId: newCredentialId,
+                publicKeyBytes: newPublicKeyBytes,
+                attestationObject,
+                clientDataJSON,
+                authenticatorAttachment,
+                transports,
+            } = await webAuthnProvider.create({
+                challenge,
+                rpId:     resolvedRpId,
+                rpName:   'Invisible Wallet',
+                userId,
+                userName: name,
+                authenticatorAttachment: options?.authenticatorAttachment,
+            });
+
+            if (newPublicKeyBytes.length !== 65) {
+                throw new Error('New credential did not yield a 65-byte uncompressed P-256 key');
+            }
+
+            // Optional attestation verification for the new credential — mirrors register().
+            if (config.attestationPolicy) {
+                if (attestationObject && clientDataJSON) {
+                    await verifyAttestation({
+                        attestationObject,
+                        clientDataJSON,
+                        policy: config.attestationPolicy,
+                    });
+                } else if (config.requireAttestation) {
+                    throw new AttestationError(
+                        'Attestation required but the platform did not expose an attestationObject.'
+                    );
+                }
+            }
+
+            // 2. Build the rotate_signer(old, new) call against the wallet contract.
+            const server = new SorobanRpc.Server(rpcUrl);
+            const walletContract = new Contract(address);
+            const sourceAccount = await server.getAccount(signerKeypair.publicKey());
+
+            const tx = new TransactionBuilder(sourceAccount, {
+                fee: BASE_FEE,
+                networkPassphrase,
+            })
+                .addOperation(
+                    walletContract.call(
+                        'rotate_signer',
+                        nativeToScVal(oldPublicKeyBytes, { type: 'bytes' }),
+                        nativeToScVal(newPublicKeyBytes, { type: 'bytes' })
+                    )
+                )
+                .setTimeout(30)
+                .build();
+
+            const sim = await server.simulateTransaction(tx);
+            if (SorobanRpc.Api.isSimulationError(sim)) {
+                throw new Error(`Simulation failed: ${sim.error}`);
+            }
+
+            const assembled = SorobanRpc.assembleTransaction(tx, sim).build();
+
+            // 3. Authorize the rotation with the CURRENT passkey. signAuthEntry reads
+            //    the still-current credential from storage, so this must run before we
+            //    persist the new credential below.
+            const successSim = sim as SorobanRpc.Api.SimulateTransactionSuccessResponse;
+            const authEntries = successSim.result?.auth;
+            if (authEntries) {
+                const networkIdBytes = new Uint8Array(
+                    (stellarHash as (input: Buffer) => Buffer)(Buffer.from(networkPassphrase))
+                );
+
+                for (const parsed of authEntries) {
+                    const cred = parsed.credentials();
+                    if (cred.switch().value !== xdr.SorobanCredentialsType.sorobanCredentialsAddress().value) {
+                        continue;
+                    }
+
+                    const addrCred = cred.address();
+                    const preimage = xdr.HashIdPreimage.envelopeTypeSorobanAuthorization(
+                        new xdr.HashIdPreimageSorobanAuthorization({
+                            networkId: Buffer.from(networkIdBytes),
+                            nonce: addrCred.nonce(),
+                            invocation: parsed.rootInvocation(),
+                            signatureExpirationLedger: addrCred.signatureExpirationLedger(),
+                        })
+                    );
+                    const payloadHash = new Uint8Array(
+                        (stellarHash as (input: Buffer) => Buffer)(Buffer.from(preimage.toXDR()))
+                    );
+
+                    const webAuthnSig = await signAuthEntry(payloadHash);
+                    if (!webAuthnSig) throw new Error('WebAuthn signing was cancelled');
+
+                    const sigVec = xdr.ScVal.scvVec([
+                        nativeToScVal(webAuthnSig.publicKey,      { type: 'bytes' }),
+                        nativeToScVal(webAuthnSig.authData,       { type: 'bytes' }),
+                        nativeToScVal(webAuthnSig.clientDataJSON, { type: 'bytes' }),
+                        nativeToScVal(webAuthnSig.signature,      { type: 'bytes' }),
+                    ]);
+
+                    parsed.credentials(
+                        xdr.SorobanCredentials.sorobanCredentialsAddress(
+                            new xdr.SorobanAddressCredentials({
+                                address: addrCred.address(),
+                                nonce: addrCred.nonce(),
+                                signatureExpirationLedger: addrCred.signatureExpirationLedger(),
+                                signature: sigVec,
+                            })
+                        )
+                    );
+                }
+            }
+
+            const submissionTx = signForSubmission(assembled, signerKeypair, config);
+
+            const sendResult = await server.sendTransaction(submissionTx);
+            if (sendResult.status === 'ERROR') {
+                throw new Error(
+                    `Transaction rejected: ${sendResult.errorResult?.toXDR('base64') ?? 'unknown error'}`
+                );
+            }
+
+            const txResult = await waitForTransaction(server, sendResult.hash);
+            if (txResult.status !== SorobanRpc.Api.GetTransactionStatus.SUCCESS) {
+                throw new Error(`Transaction failed with status: ${txResult.status}`);
+            }
+
+            // 4. Rotation confirmed on-chain — the new credential is now the active
+            //    signer. Persist it; the wallet address is intentionally untouched.
+            const newPublicKeyHex = bufferToHex(newPublicKeyBytes);
+            await store.setItem('invisible_wallet_public_key', newPublicKeyHex);
+            await store.setItem('invisible_wallet_key_id',     newCredentialId);
+
+            const resolvedAttachment = authenticatorAttachment ?? options?.authenticatorAttachment;
+            if (resolvedAttachment === 'cross-platform') {
+                const portable: PortableSigner = {
+                    credentialId: newCredentialId,
+                    publicKey: newPublicKeyHex,
+                    authenticatorAttachment: 'cross-platform',
+                    transports: transports ?? [],
+                };
+                await store.setItem(PORTABLE_SIGNER_KEY, JSON.stringify(portable));
+            } else if (store.removeItem) {
+                await store.removeItem(PORTABLE_SIGNER_KEY);
+            }
+
+            return { oldPublicKeyBytes, newPublicKeyBytes, walletAddress: address };
+
+        } catch (err: unknown) {
+            const message = err instanceof Error ? err.message : String(err);
+            setError(message);
+            throw err;
+        } finally {
+            setIsPending(false);
+        }
+    }, [address, rpcUrl, networkPassphrase, rpId, store, signAuthEntry, config]);
+
     // ── initiateRecovery ──────────────────────────────────────────────────────
 
     const initiateRecovery = useCallback(async (
@@ -1680,6 +1897,6 @@ export function useInvisibleWallet(config: WalletConfig): InvisibleWallet {
     }, [getCipher]);
 
     return useMemo(() => (
-        { address, isDeployed, isPending, error, register, deploy, signAuthEntry, deriveCounterfactualAddress, getPortableSigner, login, getNonce, addSigner, removeSigner, getSigners, setGuardian, initiateRecovery, completeRecovery, approve, getAllowance, getBalance, sendPayment, outbox, replayOutbox, encryptLocal, decryptLocal, encryptionMode }
-    ), [address, isDeployed, isPending, error, register, deploy, signAuthEntry, deriveCounterfactualAddress, getPortableSigner, login, getNonce, addSigner, removeSigner, getSigners, setGuardian, initiateRecovery, completeRecovery, approve, getAllowance, getBalance, sendPayment, outbox, replayOutbox, encryptLocal, decryptLocal, encryptionMode]);
+        { address, isDeployed, isPending, error, register, deploy, signAuthEntry, deriveCounterfactualAddress, getPortableSigner, login, getNonce, addSigner, removeSigner, rotateSigner, getSigners, setGuardian, initiateRecovery, completeRecovery, approve, getAllowance, getBalance, sendPayment, outbox, replayOutbox, encryptLocal, decryptLocal, encryptionMode }
+    ), [address, isDeployed, isPending, error, register, deploy, signAuthEntry, deriveCounterfactualAddress, getPortableSigner, login, getNonce, addSigner, removeSigner, rotateSigner, getSigners, setGuardian, initiateRecovery, completeRecovery, approve, getAllowance, getBalance, sendPayment, outbox, replayOutbox, encryptLocal, decryptLocal, encryptionMode]);
 }


### PR DESCRIPTION
Closes #278

## What
Adds passkey **signer rotation** so a user who loses a device can replace the registered P-256 key while keeping the **same wallet address and balances** — no redeploy.

## Contract — `contracts/invisible_wallet/src/lib.rs`
- New owner-authed entrypoint `rotate_signer(old_public_key, new_public_key)`:
  - Calls `env.current_contract_address().require_auth()`, so the rotation must be authorized by the **current** signer via `__check_auth`. A lost device cannot be swapped out by anyone but the current owner.
  - The new key takes over the **same index** as the old one (`storage::replace_signer`), so the signer-set size — and therefore the contract address and balances — are unchanged.
  - Guards: `InvalidPublicKey` (old == new), new `SignerAlreadyExists` (replacement already registered), `SignerNotFound` (old key not registered).

## SDK — `sdk/src/useInvisibleWallet.ts`
- New `rotateSigner(signerKeypair, username?, options?)`:
  1. Registers a brand-new WebAuthn credential (the new device).
  2. Builds and simulates `rotate_signer(old, new)`.
  3. Signs the contract authorization entry with the **current** passkey (`signAuthEntry`) — the on-chain current-signer auth.
  4. On success, persists the new credential as the active signer; the stored wallet address is intentionally left untouched.

## Acceptance criteria
- ✅ **New key authorizes after rotation, old key rejected** — the old key is removed from the signer map and the new key installed in its slot (`test_rotate_signer_swaps_key_and_keeps_address`).
- ✅ **Wallet address unchanged** — rotation only mutates storage; the contract id is preserved (asserted in the same test; SDK keeps the stored address and returns it).
- ✅ **Rotation requires current-signer auth** — `test_rotate_signer_requires_current_signer_auth` (no auth mocked → `require_auth()` panics).

## Tests
- Contract: 6 new unit tests (swap+address, preserve-other-signers, unknown old key, duplicate new key, same key, requires-auth). `cargo test -p invisible-wallet --lib` → **55 passed**.
- SDK: 2 new tests in `useInvisibleWallet.test.ts` (happy path with address preserved + new key stored; no-existing-key error). `jest useInvisibleWallet api-surface` → **20 passed**, API-surface snapshot unchanged. `tsc --noEmit` clean.

> Note: a few unrelated suites (`prf`, `attestation`, `backup`, `useBalance`, `useSendPayment`) fail locally with a `crypto.subtle.importKey` WebCrypto/jsdom environment error in code untouched by this PR — pre-existing and out of scope.