### PR TITLE
feat(wallet): add Load More pagination to transaction history

### DIFF
--- a/frontend/wallet/app/dashboard/page.tsx
+++ b/frontend/wallet/app/dashboard/page.tsx
@@ -22,7 +22,7 @@ import { sweepContractBalance } from '@/lib/sweepContractBalance'
 import { derToRawSignature, hexToUint8Array } from '@veil/utils'
 import type { WebAuthnSignature } from '@veil/sdk'
 import { getDueSchedules, updateSchedule, advanceNextRun, type PaymentSchedule } from '@/lib/schedules'
-import { useActivityFeed, initActivityFeed, hydrateActivityFeed } from '@/lib/activityFeed'
+import { useActivityFeed, initActivityFeed, hydrateActivityFeed, appendActivityFeed } from '@/lib/activityFeed'
 
 const network = getNetwork()
 
@@ -32,6 +32,65 @@ export interface WalletAsset {
   code: string
   issuer: string | null
   balance: string
+}
+
+// ── Shared types ─────────────────────────────────────────────────────────────
+
+type HorizonOp = {
+  id: string; type: string
+  from?: string; to?: string; funder?: string; account?: string
+  amount?: string; starting_balance?: string
+  asset_type?: string; asset_code?: string; asset_issuer?: string
+  source_amount?: string
+  source_asset_type?: string; source_asset_code?: string
+  created_at: string; transaction_hash: string
+  transaction?: { memo?: string }
+}
+
+type WraithTransfer = {
+  id: number; eventType: string; fromAddress: string | null
+  toAddress: string | null; amount: string; ledger: number
+  ledgerClosedAt: string; txHash: string; contractId: string
+}
+
+type WraithPage = { transfers: WraithTransfer[], next_cursor?: string | null }
+
+function mapHorizonOps(ops: HorizonOp[], signerPublicKey: string): import('@/components/TxDetailSheet').TxRecord[] {
+  return ops
+    .filter(p => p.type === 'payment' || p.type === 'create_account' || p.type === 'path_payment_strict_send')
+    .map(p => {
+      if (p.type === 'create_account') {
+        return {
+          id: p.id, type: 'received' as const,
+          amount: p.starting_balance ?? '0', asset: 'XLM',
+          counterparty: p.funder ?? 'Friendbot',
+          timestamp: Math.floor(new Date(p.created_at).getTime() / 1000),
+          hash: p.transaction_hash,
+        }
+      }
+      if (p.type === 'path_payment_strict_send') {
+        const srcAsset = p.source_asset_type === 'native' ? 'XLM' : (p.source_asset_code ?? 'XLM')
+        const dstAsset = p.asset_type === 'native' ? 'XLM' : (p.asset_code ?? '')
+        return {
+          id: p.id, type: 'swapped' as const,
+          amount: p.source_amount ?? '0', asset: srcAsset,
+          destAmount: p.amount ?? '0', destAsset: dstAsset,
+          counterparty: 'Stellar DEX',
+          timestamp: Math.floor(new Date(p.created_at).getTime() / 1000),
+          hash: p.transaction_hash,
+        }
+      }
+      return {
+        id: p.id,
+        type: p.from === signerPublicKey ? 'sent' as const : 'received' as const,
+        amount: p.amount ?? '0',
+        asset: p.asset_type === 'native' ? 'XLM' : (p.asset_code ?? ''),
+        counterparty: p.from === signerPublicKey ? (p.to ?? '') : (p.from ?? ''),
+        timestamp: Math.floor(new Date(p.created_at).getTime() / 1000),
+        hash: p.transaction_hash,
+        memo: p.transaction?.memo,
+      }
+    })
 }
 
 // ── Module-level cache ────────────────────────────────────────────────────────
@@ -67,6 +126,11 @@ function DashboardPageContent() {
   const [showConnectDapp, setShowConnectDapp] = useState(false)
   const [connectToast, setConnectToast] = useState<string | null>(null)
   const [sep24Modal, setSep24Modal] = useState<'deposit' | 'withdraw' | null>(null)
+  const [wraithInCursor, setWraithInCursor]   = useState<string | null>(null)
+  const [wraithOutCursor, setWraithOutCursor] = useState<string | null>(null)
+  const [hasMorePages, setHasMorePages]       = useState(false)
+  const [isLoadingMore, setIsLoadingMore]     = useState(false)
+  const horizonNextRef = useRef<(() => Promise<any>) | null>(null)
 
   useEffect(() => {
     const stored = sessionStorage.getItem('invisible_wallet_address')
@@ -84,6 +148,10 @@ function DashboardPageContent() {
   const fetchData = useCallback(async () => {
     if (!walletAddress) return   // keep loading=true until address is ready
     if (cachedAssets === null) setLoading(true)
+    horizonNextRef.current = null
+    setWraithInCursor(null)
+    setWraithOutCursor(null)
+    setHasMorePages(false)
 
     const horizonServer = new Server(network.horizonUrl)
     const rpcServer     = new SorobanRpc.Server(network.rpcUrl)
@@ -142,76 +210,24 @@ function DashboardPageContent() {
           .map(b => ({ code: b.asset_code, issuer: b.asset_issuer, balance: b.balance }))
 
         // Transaction history (fee-payer account)
-        type HorizonOp = {
-          id: string; type: string
-          from?: string; to?: string; funder?: string; account?: string
-          amount?: string; starting_balance?: string
-          asset_type?: string; asset_code?: string; asset_issuer?: string
-          source_amount?: string
-          source_asset_type?: string; source_asset_code?: string
-          created_at: string; transaction_hash: string
-          transaction?: { memo?: string }
-        }
-
-        const payments = await horizonServer
+        const paymentsPage = await horizonServer
           .payments()
           .forAccount(signerPublicKey)
           .limit(20)
           .order('desc')
           .call()
 
-        txRecords = (payments.records as HorizonOp[])
-          .filter(p => p.type === 'payment' || p.type === 'create_account' || p.type === 'path_payment_strict_send')
-          .map(p => {
-            if (p.type === 'create_account') {
-              return {
-                id:           p.id,
-                type:         'received' as const,
-                amount:       p.starting_balance ?? '0',
-                asset:        'XLM',
-                counterparty: p.funder ?? 'Friendbot',
-                timestamp:    Math.floor(new Date(p.created_at).getTime() / 1000),
-                hash:         p.transaction_hash,
-              }
-            }
-            if (p.type === 'path_payment_strict_send') {
-              const srcAsset = p.source_asset_type === 'native' ? 'XLM' : (p.source_asset_code ?? 'XLM')
-              const dstAsset = p.asset_type === 'native' ? 'XLM' : (p.asset_code ?? '')
-              return {
-                id:           p.id,
-                type:         'swapped' as const,
-                amount:       p.source_amount ?? '0',
-                asset:        srcAsset,
-                destAmount:   p.amount ?? '0',
-                destAsset:    dstAsset,
-                counterparty: 'Stellar DEX',
-                timestamp:    Math.floor(new Date(p.created_at).getTime() / 1000),
-                hash:         p.transaction_hash,
-              }
-            }
-            return {
-              id:           p.id,
-              type:         p.from === signerPublicKey ? 'sent' as const : 'received' as const,
-              amount:       p.amount ?? '0',
-              asset:        p.asset_type === 'native' ? 'XLM' : (p.asset_code ?? ''),
-              counterparty: p.from === signerPublicKey ? (p.to ?? '') : (p.from ?? ''),
-              timestamp:    Math.floor(new Date(p.created_at).getTime() / 1000),
-              hash:         p.transaction_hash,
-              memo:         p.transaction?.memo,
-            }
-          })
+        horizonNextRef.current = paymentsPage.records.length >= 20 ? paymentsPage.next : null
+        txRecords = mapHorizonOps(paymentsPage.records as HorizonOp[], signerPublicKey)
       } catch { /* not yet funded */ }
     }
 
     // ── 3. Wraith: incoming SAC transfers to the wallet contract ────────────
     const wraithUrl = process.env.NEXT_PUBLIC_WRAITH_URL
+    let localInCursor: string | null = null
+    let localOutCursor: string | null = null
     if (wraithUrl) {
       try {
-        type WraithTransfer = {
-          id: number; eventType: string; fromAddress: string | null
-          toAddress: string | null; amount: string; ledger: number
-          ledgerClosedAt: string; txHash: string; contractId: string
-        }
         // Incoming: to wallet C... address
         // Outgoing: from fee-payer G... address (sends go from fee-payer, not contract)
         const feePayerAddr = signerPublicKey || walletAddress
@@ -219,8 +235,12 @@ function DashboardPageContent() {
           fetch(`${wraithUrl}/transfers/incoming/${walletAddress}?limit=20`),
           fetch(`${wraithUrl}/transfers/outgoing/${feePayerAddr}?limit=20`),
         ])
-        const inData  = inRes.ok  ? await inRes.json()  as { transfers: WraithTransfer[] } : { transfers: [] }
-        const outData = outRes.ok ? await outRes.json() as { transfers: WraithTransfer[] } : { transfers: [] }
+        const inData  = inRes.ok  ? await inRes.json()  as WraithPage : { transfers: [] as WraithTransfer[], next_cursor: null }
+        const outData = outRes.ok ? await outRes.json() as WraithPage : { transfers: [] as WraithTransfer[], next_cursor: null }
+        localInCursor  = inData.next_cursor  ?? null
+        localOutCursor = outData.next_cursor ?? null
+        setWraithInCursor(localInCursor)
+        setWraithOutCursor(localOutCursor)
 
         const wraithRecords: TxRecord[] = [
           ...inData.transfers.map(t => ({
@@ -286,6 +306,7 @@ function DashboardPageContent() {
     hydrateActivityFeed(txRecords)
     if (signerPublicKey) initActivityFeed(signerPublicKey)
 
+    setHasMorePages(horizonNextRef.current !== null || localInCursor !== null || localOutCursor !== null)
     setLoading(false)
   }, [walletAddress])
 
@@ -305,6 +326,75 @@ function DashboardPageContent() {
     document.addEventListener('visibilitychange', onVisible)
     return () => document.removeEventListener('visibilitychange', onVisible)
   }, [fetchData])
+
+  const handleLoadMore = useCallback(async () => {
+    if (!walletAddress) return
+    setIsLoadingMore(true)
+    try {
+      const signerSecret    = sessionStorage.getItem('veil_signer_secret')
+      const signerPublicKey = signerSecret
+        ? Keypair.fromSecret(signerSecret).publicKey()
+        : (localStorage.getItem('veil_signer_public_key') || '')
+
+      const additionalRecords: import('@/components/TxDetailSheet').TxRecord[] = []
+
+      if (horizonNextRef.current) {
+        try {
+          const page = await horizonNextRef.current()
+          additionalRecords.push(...mapHorizonOps(page.records as HorizonOp[], signerPublicKey))
+          horizonNextRef.current = page.records.length >= 20 ? page.next : null
+        } catch { /* Horizon unavailable */ }
+      }
+
+      const wraithUrl = process.env.NEXT_PUBLIC_WRAITH_URL
+      let newInCursor: string | null = null
+      let newOutCursor: string | null = null
+
+      if (wraithUrl && (wraithInCursor || wraithOutCursor)) {
+        try {
+          const feePayerAddr = signerPublicKey || walletAddress
+          const fetches: Promise<Response>[] = []
+          if (wraithInCursor)  fetches.push(fetch(`${wraithUrl}/transfers/incoming/${walletAddress}?limit=20&cursor=${wraithInCursor}`))
+          if (wraithOutCursor) fetches.push(fetch(`${wraithUrl}/transfers/outgoing/${feePayerAddr}?limit=20&cursor=${wraithOutCursor}`))
+          const responses = await Promise.all(fetches)
+          let idx = 0
+
+          if (wraithInCursor) {
+            const res = responses[idx++]
+            const data = res.ok ? await res.json() as WraithPage : { transfers: [] as WraithTransfer[], next_cursor: null }
+            newInCursor = data.next_cursor ?? null
+            additionalRecords.push(...data.transfers.map(t => ({
+              id: `w-${t.id}`, type: 'received' as const,
+              amount: (Math.abs(Number(t.amount)) / 10_000_000).toFixed(7), asset: 'XLM',
+              counterparty: t.fromAddress ?? 'unknown',
+              timestamp: Math.floor(new Date(t.ledgerClosedAt).getTime() / 1000),
+              hash: t.txHash,
+            })))
+          }
+
+          if (wraithOutCursor) {
+            const res = responses[idx++]
+            const data = res.ok ? await res.json() as WraithPage : { transfers: [] as WraithTransfer[], next_cursor: null }
+            newOutCursor = data.next_cursor ?? null
+            additionalRecords.push(...data.transfers.map(t => ({
+              id: `w-${t.id}`, type: 'sent' as const,
+              amount: (Math.abs(Number(t.amount)) / 10_000_000).toFixed(7), asset: 'XLM',
+              counterparty: t.toAddress ?? 'unknown',
+              timestamp: Math.floor(new Date(t.ledgerClosedAt).getTime() / 1000),
+              hash: t.txHash,
+            })))
+          }
+        } catch { /* Wraith unavailable — hide button, keep existing list */ }
+      }
+
+      setWraithInCursor(newInCursor)
+      setWraithOutCursor(newOutCursor)
+      setHasMorePages(horizonNextRef.current !== null || newInCursor !== null || newOutCursor !== null)
+      if (additionalRecords.length > 0) appendActivityFeed(additionalRecords)
+    } finally {
+      setIsLoadingMore(false)
+    }
+  }, [walletAddress, wraithInCursor, wraithOutCursor])
 
   // Fetch live USDC prices from Lens after balances load.
   // Runs in the background — does not block balance rendering and does not
@@ -908,6 +998,30 @@ function DashboardPageContent() {
               </div>
             )
           })()}
+
+          {hasMorePages && !loading && (
+            <div style={{ marginTop: '1rem', display: 'flex', justifyContent: 'center' }}>
+              <button
+                onClick={handleLoadMore}
+                disabled={isLoadingMore}
+                style={{
+                  padding: '0.625rem 1.5rem',
+                  borderRadius: '100px',
+                  border: '1px solid rgba(246,247,248,0.2)',
+                  background: 'transparent',
+                  color: 'rgba(246,247,248,0.6)',
+                  fontSize: '0.8125rem',
+                  cursor: isLoadingMore ? 'default' : 'pointer',
+                  display: 'flex', alignItems: 'center', gap: '0.5rem',
+                  transition: 'all 120ms',
+                }}
+              >
+                {isLoadingMore
+                  ? <div className="spinner" style={{ width: '14px', height: '14px' }} />
+                  : 'Load more'}
+              </button>
+            </div>
+          )}
         </section>
 
       </main>

--- a/frontend/wallet/lib/activityFeed.ts
+++ b/frontend/wallet/lib/activityFeed.ts
@@ -69,6 +69,13 @@ export function hydrateActivityFeed(records: TxRecord[]): void {
   notify()
 }
 
+export function appendActivityFeed(newRecords: TxRecord[]): void {
+  const deduped = newRecords.filter(r => !_records.some(existing => existing.hash === r.hash))
+  if (deduped.length === 0) return
+  _records = [..._records, ...deduped].sort((a, b) => b.timestamp - a.timestamp)
+  notify()
+}
+
 export function subscribeActivityFeed(listener: ActivityListener): () => void {
   _listeners.add(listener)
   listener([..._records])


### PR DESCRIPTION
## Summary

- Adds cursor-based pagination to the dashboard activity feed
- `fetchData` now captures Wraith `next_cursor` (incoming + outgoing) and Horizon `next()` function after each initial load
- New `handleLoadMore` appends older records via `appendActivityFeed` (new export on `activityFeed.ts`) without replacing the existing list
- "Load more" button appears below the activity section only when the server has more pages; shows a spinner during fetch; hides when pages exhausted or Wraith is unavailable

## Changes

- `frontend/wallet/lib/activityFeed.ts` — adds `appendActivityFeed`: deduplicates by hash, merges, re-sorts descending by timestamp, notifies subscribers
- `frontend/wallet/app/dashboard/page.tsx`:
  - Extracts `HorizonOp`, `WraithTransfer`, `WraithPage` types and `mapHorizonOps` helper to module level (shared by initial fetch and load-more)
  - Adds `wraithInCursor`, `wraithOutCursor`, `hasMorePages`, `isLoadingMore` state and `horizonNextRef`
  - Updates `fetchData` to reset cursors on refresh, store Wraith `next_cursor` and Horizon `next()`, set `hasMorePages`
  - Adds `handleLoadMore` callback: fetches next Horizon page + next Wraith pages, appends results
  - Renders "Load more" button below activity list when `hasMorePages && !loading`

## Verification

- Button hidden when initial page returns < 20 records and Wraith has no `next_cursor`
- Clicking appends, not replaces; duplicates filtered by hash
- Refresh resets to page 1 (cursors cleared at start of `fetchData`)
- Wraith unavailable during load-more → catch block → cursors stay null → button hidden, list intact
- TypeScript: no new errors in changed files (pre-existing missing-dep errors unrelated)

Closes #92