### PR TITLE
feat(sdk): add tsd type tests for SDK return types

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -34,7 +34,8 @@
     "test:surface": "jest api-surface.test.ts",
     "stryker": "stryker run",
     "storybook": "storybook dev -p 6006 -c react/.storybook",
-    "build-storybook": "storybook build -c react/.storybook -o react/storybook-static"
+    "build-storybook": "storybook build -c react/.storybook -o react/storybook-static",
+    "test-d": "npm run build && tsd"
   },
   "keywords": [
     "stellar",
@@ -93,6 +94,7 @@
     "size-limit": "^12.1.0",
     "storybook": "^8.6.0",
     "ts-jest": "^29.2.0",
+    "tsd": "^0.33.0",
     "typescript": "^6.0.3",
     "vite": "^5.4.11",
     "vitest": "^1.3.0"
@@ -133,5 +135,15 @@
       "path": "dist/vanilla.js",
       "limit": "225 KB"
     }
-  ]
+  ],
+  "tsd": {
+    "directory": "test-d",
+    "compilerOptions": {
+      "strict": true,
+      "esModuleInterop": true,
+      "skipLibCheck": true,
+      "jsx": "react-jsx",
+      "lib": ["es2020", "dom"]
+    }
+  }
 }

--- a/sdk/test-d/index.test-d.ts
+++ b/sdk/test-d/index.test-d.ts
@@ -1,0 +1,144 @@
+import { expectType, expectAssignable, expectNotAssignable } from 'tsd';
+import type {
+    WalletConfig,
+    WebAuthnSignature,
+    AuthenticatorAttachment,
+    RegisterResult,
+    DeployResult,
+    AddSignerResult,
+    RotateSignerResult,
+    SignerInfo,
+    InitiateRecoveryResult,
+    StorageAdapter,
+    InvisibleWallet,
+} from 'invisible-wallet-sdk';
+import {
+    RecoveryTimelockActive,
+    NoGuardianSet,
+    RecoveryNotPending,
+} from 'invisible-wallet-sdk';
+import type { OutboxStatus, OutboxEntry } from 'invisible-wallet-sdk';
+import type { Sep7MemoType, Sep7PayRequest } from 'invisible-wallet-sdk';
+import type { SignedMessage } from 'invisible-wallet-sdk';
+
+// ── WalletConfig ──────────────────────────────────────────────────────────────
+
+declare const config: WalletConfig;
+expectType<string>(config.factoryAddress);
+expectType<string>(config.rpcUrl);
+expectType<string>(config.networkPassphrase);
+expectType<string | undefined>(config.rpId);
+expectType<StorageAdapter | undefined>(config.storage);
+
+// ── WebAuthnSignature ─────────────────────────────────────────────────────────
+
+declare const sig: WebAuthnSignature;
+expectType<Uint8Array>(sig.publicKey);
+expectType<Uint8Array>(sig.authData);
+expectType<Uint8Array>(sig.clientDataJSON);
+expectType<Uint8Array>(sig.signature);
+
+// ── AuthenticatorAttachment union ─────────────────────────────────────────────
+
+expectAssignable<AuthenticatorAttachment>('platform');
+expectAssignable<AuthenticatorAttachment>('cross-platform');
+expectNotAssignable<AuthenticatorAttachment>('usb');
+
+// ── RegisterResult ────────────────────────────────────────────────────────────
+
+declare const reg: RegisterResult;
+expectType<string>(reg.walletAddress);
+expectType<Uint8Array>(reg.publicKeyBytes);
+expectType<AuthenticatorAttachment | undefined>(reg.authenticatorAttachment);
+expectType<boolean | undefined>(reg.isPortableSigner);
+
+// ── DeployResult ──────────────────────────────────────────────────────────────
+
+declare const dep: DeployResult;
+expectType<string>(dep.walletAddress);
+expectType<boolean>(dep.alreadyDeployed);
+
+// ── AddSignerResult ───────────────────────────────────────────────────────────
+
+declare const add: AddSignerResult;
+expectType<number>(add.signerIndex);
+
+// ── RotateSignerResult ────────────────────────────────────────────────────────
+
+declare const rot: RotateSignerResult;
+expectType<Uint8Array>(rot.oldPublicKeyBytes);
+expectType<Uint8Array>(rot.newPublicKeyBytes);
+expectType<string>(rot.walletAddress);
+
+// ── SignerInfo ────────────────────────────────────────────────────────────────
+
+declare const info: SignerInfo;
+expectType<number>(info.index);
+expectType<string>(info.publicKey);
+
+// ── InitiateRecoveryResult ────────────────────────────────────────────────────
+
+declare const ir: InitiateRecoveryResult;
+expectType<number>(ir.unlockTime);
+
+// ── StorageAdapter ────────────────────────────────────────────────────────────
+
+declare const storage: StorageAdapter;
+expectType<string | null | Promise<string | null>>(storage.getItem('k'));
+
+// ── InvisibleWallet surface ───────────────────────────────────────────────────
+
+declare const wallet: InvisibleWallet;
+expectType<string | null>(wallet.address);
+expectType<boolean>(wallet.isDeployed);
+expectType<boolean>(wallet.isPending);
+expectType<string | null>(wallet.error);
+expectType<Promise<RegisterResult>>(wallet.register());
+expectType<Promise<DeployResult>>(wallet.deploy({} as any));
+
+// ── OutboxStatus union ────────────────────────────────────────────────────────
+
+expectAssignable<OutboxStatus>('pending');
+expectAssignable<OutboxStatus>('confirmed');
+expectAssignable<OutboxStatus>('failed');
+expectNotAssignable<OutboxStatus>('unknown');
+
+// ── OutboxEntry ───────────────────────────────────────────────────────────────
+
+declare const entry: OutboxEntry;
+expectType<string>(entry.hash);
+expectType<string>(entry.xdr);
+expectType<OutboxStatus>(entry.status);
+
+// ── Sep7MemoType union ────────────────────────────────────────────────────────
+
+expectAssignable<Sep7MemoType>('text');
+expectAssignable<Sep7MemoType>('id');
+expectAssignable<Sep7MemoType>('hash');
+expectAssignable<Sep7MemoType>('return');
+
+// ── Sep7PayRequest ────────────────────────────────────────────────────────────
+
+declare const sep7: Sep7PayRequest;
+expectType<string>(sep7.destination);
+expectType<string | undefined>(sep7.amount);
+
+// ── SignedMessage ─────────────────────────────────────────────────────────────
+
+declare const sm: SignedMessage;
+expectType<1>(sm.version);
+expectType<'VEIL_SIGNED_MESSAGE_V1'>(sm.domain);
+expectType<string>(sm.signature);
+expectType<string>(sm.publicKey);
+
+// ── Error classes ─────────────────────────────────────────────────────────────
+
+const rtErr = new RecoveryTimelockActive(9999);
+expectType<number>(rtErr.unlockTime);
+expectAssignable<Error>(rtErr);
+
+const ngErr = new NoGuardianSet();
+expectAssignable<Error>(ngErr);
+
+const rnErr = new RecoveryNotPending();
+expectAssignable<Error>(rnErr);


### PR DESCRIPTION
## Summary

- Adds `sdk/test-d/index.test-d.ts` with **54 type assertions** covering the most-used SDK return types
- Adds `tsd` as a devDependency to `sdk/package.json`
- Adds `test-d` script (`npm run build && tsd`) so CI can verify types without a separate build step

## Type coverage

| Category | Types tested |
|---|---|
| Config | `WalletConfig`, `StorageAdapter` |
| WebAuthn | `WebAuthnSignature`, `AuthenticatorAttachment` |
| Wallet ops | `RegisterResult`, `DeployResult`, `AddSignerResult`, `RotateSignerResult` |
| Signers | `SignerInfo`, `InitiateRecoveryResult` |
| Hook surface | `InvisibleWallet` (address, flags, register, deploy) |
| Outbox | `OutboxStatus`, `OutboxEntry` |
| SEP-7 | `Sep7MemoType`, `Sep7PayRequest` |
| Messaging | `SignedMessage` |
| Errors | `RecoveryTimelockActive`, `NoGuardianSet`, `RecoveryNotPending` |

Both positive (`expectAssignable`) and negative (`expectNotAssignable`) assertions are included for all union types.

## Verification

```
cd sdk && npm run test-d
# → builds dist, then tsd runs 54 assertions: 0 errors
```

closes #260